### PR TITLE
added unix domain socket limit workaround

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "bufferutil": "4.0.8",
     "electron-trpc": "^0.5.2",
     "hc-launcher-rust-utils": "file:./rust-utils/dist",
+    "nanoid": "5.0.4",
     "split": "1.0.1",
     "winston": "3.11.0",
     "zod": "^3.22.4"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3162,6 +3162,11 @@ mz@^2.7.0:
     object-assign "^4.0.1"
     thenify-all "^1.0.0"
 
+nanoid@5.0.4:
+  version "5.0.4"
+  resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-5.0.4.tgz#d2b608d8169d7da669279127615535705aa52edf"
+  integrity sha512-vAjmBf13gsmhXSgBrtIclinISzFFy22WwCYoyilZlsrRXNIHSwgFQ1bEdjRwMT3aoadeIF6HMuDRlOxzfXV8ig==
+
 nanoid@^3.3.6, nanoid@^3.3.7:
   version "3.3.7"
   resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.3.7.tgz#d0c301a691bc8d54efa0a2226ccf3fe2fd656bd8"


### PR DESCRIPTION
Fixes [this](https://github.com/holochain/launcher/issues/144) issue about too long unix domain sockets for lair keystore.