### PR TITLE
Decouple storing of UI/happ from installing webhapp

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -39,11 +39,13 @@ import type {
   WindowInfoRecord,
 } from '$shared/types';
 import {
+  BytesSchema,
   CHECK_INITIALIZED_KEYSTORE_ERROR,
   ExtendedAppInfoSchema,
   InstallDefaultAppSchema,
   InstallHappFromPathSchema,
-  InstallHappInputSchema,
+  InstallHappOrWebhappFromBytesSchema,
+  InstallWebhappFromHashesSchema,
   LOADING_PROGRESS_UPDATE,
   MAIN_SCREEN_ROUTE,
   MainScreenRouteSchema,
@@ -429,7 +431,7 @@ async function handleLaunch(password: string) {
         LAUNCHER_EMITTER.emit(LOADING_PROGRESS_UPDATE, progressUpdate);
         const happPath = path.join(DEFAULT_APPS_DIRECTORY, name);
         const happBytes = fs.readFileSync(happPath);
-        await holochainManager.installHeadlessHapp(
+        await holochainManager.installHeadlessHappFromBytes(
           Array.from(happBytes),
           id,
           defaultAppsNetworkSeed,
@@ -523,24 +525,51 @@ const router = t.router({
     const holochainManager = getHolochainManager(HOLOCHAIN_DATA_ROOT!.name);
 
     if (happAndUiBytes.uiBytes) {
-      await holochainManager.installWebHapp(happAndUiBytes, appId, networkSeed);
+      await holochainManager.installWebHappFromBytes(happAndUiBytes, appId, networkSeed);
     } else {
-      await holochainManager.installHeadlessHapp(happAndUiBytes.happBytes, appId, networkSeed);
+      await holochainManager.installHeadlessHappFromBytes(
+        happAndUiBytes.happBytes,
+        appId,
+        networkSeed,
+      );
     }
   }),
-  installHappFromBytes: t.procedure.input(InstallHappInputSchema).mutation(async (opts) => {
-    const { bytes, appId, networkSeed } = opts.input;
-
-    const happAndUiBytes = await rustUtils.decodeHappOrWebhapp(Array.from(bytes));
-
+  storeUiBytes: t.procedure.input(BytesSchema).mutation(async (opts) => {
+    const { bytes } = opts.input;
     const holochainManager = getHolochainManager(HOLOCHAIN_DATA_ROOT!.name);
-
-    if (happAndUiBytes.uiBytes) {
-      await holochainManager.installWebHapp(happAndUiBytes, appId, networkSeed);
-    } else {
-      await holochainManager.installHeadlessHapp(happAndUiBytes.happBytes, appId, networkSeed);
-    }
+    return holochainManager.storeUiIfNecessary(Array.from(bytes));
   }),
+  storeHappBytes: t.procedure.input(BytesSchema).mutation(async (opts) => {
+    const { bytes } = opts.input;
+    const holochainManager = getHolochainManager(HOLOCHAIN_DATA_ROOT!.name);
+    return holochainManager.storeHapp(Array.from(bytes));
+  }),
+  installWebhappFromHashes: t.procedure
+    .input(InstallWebhappFromHashesSchema) // TODO: need metadata input as well here like name and action hash of app and app version in app store
+    .mutation(async (opts) => {
+      const { happSha256, uiZipSha256, appId, networkSeed } = opts.input;
+      const holochainManager = getHolochainManager(HOLOCHAIN_DATA_ROOT!.name);
+      await holochainManager.installWebhappFromHashes(happSha256, uiZipSha256, appId, networkSeed);
+    }),
+  installWebhappFromBytes: t.procedure
+    .input(InstallHappOrWebhappFromBytesSchema)
+    .mutation(async (opts) => {
+      const { bytes, appId, networkSeed } = opts.input;
+
+      const happAndUiBytes = await rustUtils.decodeHappOrWebhapp(Array.from(bytes));
+
+      const holochainManager = getHolochainManager(HOLOCHAIN_DATA_ROOT!.name);
+
+      if (happAndUiBytes.uiBytes) {
+        await holochainManager.installWebHappFromBytes(happAndUiBytes, appId, networkSeed);
+      } else {
+        await holochainManager.installHeadlessHappFromBytes(
+          happAndUiBytes.happBytes,
+          appId,
+          networkSeed,
+        );
+      }
+    }),
   installDefaultApp: t.procedure.input(InstallDefaultAppSchema).mutation(async (opts) => {
     const { name, appId, networkSeed } = opts.input;
 
@@ -551,9 +580,13 @@ const router = t.router({
     const holochainManager = getHolochainManager(HOLOCHAIN_DATA_ROOT!.name);
 
     if (happAndUiBytes.uiBytes) {
-      await holochainManager.installWebHapp(happAndUiBytes, appId, networkSeed);
+      await holochainManager.installWebHappFromBytes(happAndUiBytes, appId, networkSeed);
     } else {
-      await holochainManager.installHeadlessHapp(happAndUiBytes.happBytes, appId, networkSeed);
+      await holochainManager.installHeadlessHappFromBytes(
+        happAndUiBytes.happBytes,
+        appId,
+        networkSeed,
+      );
     }
   }),
   getKandoBytes: t.procedure.query(async () => {

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -534,6 +534,14 @@ const router = t.router({
       );
     }
   }),
+  isHappAvailableAndValid: t.procedure.input(z.string()).mutation(async (opts) => {
+    const holochainManager = getHolochainManager(HOLOCHAIN_DATA_ROOT!.name);
+    return holochainManager.isHappAvailableAndValid(opts.input);
+  }),
+  isUiAvailable: t.procedure.input(z.string()).mutation(async (opts) => {
+    const holochainManager = getHolochainManager(HOLOCHAIN_DATA_ROOT!.name);
+    return holochainManager.isUiAvailable(opts.input);
+  }),
   storeUiBytes: t.procedure.input(BytesSchema).mutation(async (opts) => {
     const { bytes } = opts.input;
     const holochainManager = getHolochainManager(HOLOCHAIN_DATA_ROOT!.name);

--- a/src/shared/types/holochain.ts
+++ b/src/shared/types/holochain.ts
@@ -73,7 +73,7 @@ export const InstallDefaultAppSchema = CommonAppSchema.extend({
 
 export type InstallDefaultApp = z.infer<typeof InstallDefaultAppSchema>;
 
-export const InstallHappInputSchema = CommonAppSchema.extend({
+export const InstallHappOrWebhappFromBytesSchema = CommonAppSchema.extend({
   bytes: z.instanceof(Uint8Array),
 });
 
@@ -81,7 +81,16 @@ export const InstallHappFromPathSchema = CommonAppSchema.extend({
   filePath: z.string(),
 });
 
-export type InstallHappInput = z.infer<typeof InstallHappInputSchema>;
+export const InstallWebhappFromHashesSchema = CommonAppSchema.extend({
+  happSha256: z.string(),
+  uiZipSha256: z.string(),
+});
+
+export type InstallHappOrWebhappInput = z.infer<typeof InstallHappOrWebhappFromBytesSchema>;
+
+export const BytesSchema = z.object({
+  bytes: z.instanceof(Uint8Array),
+});
 
 const HolochainDataRootSchema = z.union([
   z.object({


### PR DESCRIPTION
* Adds methods on the HolochainManager to check whether UI assets or a happ file with a specific sha256 are already available on disk and don't need to get fetched from devhub
* Adds method to install a webhapp based on sha256 hashes only (if happ and UI are already available on disk from previous installations of the same app type)