### PR TITLE
remove holochain_client dependency

### DIFF
--- a/rust-utils/Cargo.toml
+++ b/rust-utils/Cargo.toml
@@ -7,7 +7,6 @@ version = "0.201.0"
 crate-type = ["cdylib"]
 
 [dependencies]
-holochain_client = "0.5.0-dev.31"
 holochain_conductor_api = "0.3.0-beta-dev.43"
 holochain_integrity_types = "0.3.0-beta-dev.29"
 holochain_p2p = "0.3.0-beta-dev.41"


### PR DESCRIPTION
I don't know why this unnecessary dependency was still there and I think we will not get the Windows CI error anymore without it.