### PR TITLE
fix auto-updater for macOS and Windows

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -295,20 +295,8 @@ app.whenReady().then(async () => {
       });
       if (userDecision.response === 1) {
         // downloading means that with the next start of the application it's automatically going to be installed
+        autoUpdater.on('update-downloaded', () => autoUpdater.quitAndInstall());
         await autoUpdater.downloadUpdate();
-        const options: Electron.RelaunchOptions = {
-          args: process.argv,
-        };
-        // https://github.com/electron-userland/electron-builder/issues/1727#issuecomment-769896927
-        if (process.env.APPIMAGE) {
-          options.args!.unshift('--appimage-extract-and-run');
-          options.execPath = process.env.APPIMAGE.replace(
-            appVersion,
-            updateCheckResult.updateInfo.version,
-          );
-        }
-        app.relaunch(options);
-        app.exit(0);
       }
     }
   }


### PR DESCRIPTION
The previous auto updater logic turned out to only work on Linux. Fixed it such that it should also work on macOS and Windows.