### PR TITLE
rename app and binaries

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -140,19 +140,19 @@ jobs:
           dotnet tool install --global --version 4.0.1 AzureSignTool
 
           echo "sha512 before code signing"
-          CertUtil -hashfile "dist/holochain-launcher-electron-${{ steps.version.outputs.APP_VERSION }}-setup.exe" SHA512
+          CertUtil -hashfile "dist/holochain-launcher-0.4-${{ steps.version.outputs.APP_VERSION }}-setup.exe" SHA512
 
-          AzureSignTool sign -kvu "${{ secrets.AZURE_KEY_VAULT_URI }}" -kvi "${{ secrets.AZURE_CLIENT_ID }}" -kvt "${{ secrets.AZURE_TENANT_ID }}" -kvs "${{ secrets.AZURE_CLIENT_SECRET }}" -kvc ${{ secrets.AZURE_CERT_NAME }} -tr http://timestamp.digicert.com -v "dist/holochain-launcher-electron-${{ steps.version.outputs.APP_VERSION }}-setup.exe"
+          AzureSignTool sign -kvu "${{ secrets.AZURE_KEY_VAULT_URI }}" -kvi "${{ secrets.AZURE_CLIENT_ID }}" -kvt "${{ secrets.AZURE_TENANT_ID }}" -kvs "${{ secrets.AZURE_CLIENT_SECRET }}" -kvc ${{ secrets.AZURE_CERT_NAME }} -tr http://timestamp.digicert.com -v "dist/holochain-launcher-0.4-${{ steps.version.outputs.APP_VERSION }}-setup.exe"
 
           echo "sha512 after code signing"
-          CertUtil -hashfile "dist/holochain-launcher-electron-${{ steps.version.outputs.APP_VERSION }}-setup.exe" SHA512
+          CertUtil -hashfile "dist/holochain-launcher-0.4-${{ steps.version.outputs.APP_VERSION }}-setup.exe" SHA512
 
           # Overwrite the latest.yml with one containing the sha512 of the code signed setup.exe file
           node ./scripts/latest-yaml.js
           gh release upload "latest.yml" "latest.yml" --clobber
 
           # Overwrite the setup.exe file with the code signed one
-          gh release upload "v${{ steps.version.outputs.APP_VERSION }}" "dist/holochain-launcher-electron-${{ steps.version.outputs.APP_VERSION }}-setup.exe" --clobber
+          gh release upload "v${{ steps.version.outputs.APP_VERSION }}" "dist/holochain-launcher-0.4-${{ steps.version.outputs.APP_VERSION }}-setup.exe" --clobber
 
       - name: Merge latest-mac.yml mac release files
         if: matrix.platform == 'macos-latest' || matrix.platform == 'macos-11'

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "holochain-launcher-electron",
+  "name": "holochain-launcher-0.4",
   "version": "0.400.0-alpha.6",
   "private": true,
   "description": "Holochain Launcher (0.4)",

--- a/scripts/check-binaries.mjs
+++ b/scripts/check-binaries.mjs
@@ -6,7 +6,7 @@ const packageJson = JSON.parse(packageJSON);
 
 // Check whether holochain binary is in resources/bins folder
 const binariesDirectory = path.join('resources', 'bins');
-const expectedHolochainBinary = `holochain-v${packageJson.binaries.holochain}${
+const expectedHolochainBinary = `holochain-v${packageJson.binaries.holochain}${packageJson.name.replace('holochain', '')}${
   process.platform === 'win32' ? '.exe' : ''
 }`;
 if (!fs.existsSync(path.join(binariesDirectory, expectedHolochainBinary))) {
@@ -17,7 +17,7 @@ if (!fs.existsSync(path.join(binariesDirectory, expectedHolochainBinary))) {
 }
 
 // Check whether lair binary is in resources/bins folder
-const expectedLairBinary = `lair-keystore-v${packageJson.binaries.lair_keystore}${
+const expectedLairBinary = `lair-keystore-v${packageJson.binaries.lair_keystore}${packageJson.name.replace('holochain', '')}${
   process.platform === 'win32' ? '.exe' : ''
 }`;
 if (!fs.existsSync(path.join(binariesDirectory, expectedLairBinary))) {

--- a/scripts/fetch-binaries.mjs
+++ b/scripts/fetch-binaries.mjs
@@ -36,11 +36,11 @@ switch (process.platform) {
     throw new Error(`Got unexpected OS platform: ${process.platform}`);
 }
 
-const holochainBinaryFilename = `holochain-v${packageJson.binaries.holochain}${
+const holochainBinaryFilename = `holochain-v${packageJson.binaries.holochain}${packageJson.name.replace('holochain', '')}${
   process.platform === 'win32' ? '.exe' : ''
 }`;
 
-const lairBinaryFilename = `lair-keystore-v${packageJson.binaries.lair_keystore}${
+const lairBinaryFilename = `lair-keystore-v${packageJson.binaries.lair_keystore}${packageJson.name.replace('holochain', '')}${
   process.platform === 'win32' ? '.exe' : ''
 }`;
 

--- a/src/main/binaries.ts
+++ b/src/main/binaries.ts
@@ -10,9 +10,7 @@ const getFilePath = (relativePath: string) => path.join(app.getAppPath(), relati
 const getPackageJSONPath = () =>
   getFilePath(app.isPackaged ? '../app.asar.unpacked/package.json' : './package.json');
 
-const readJSONFile = (filePath: string) => JSON.parse(readFileSync(filePath, 'utf8'));
-
-const packageJSON = readJSONFile(getPackageJSONPath());
+const packageJSON = JSON.parse(readFileSync(getPackageJSONPath(), 'utf8'));
 
 const HolochainLairVersion = HolochainLairVersionSchema.parse(packageJSON);
 
@@ -26,13 +24,13 @@ const BINARIES_DIRECTORY = getFilePath(
 const HOLOCHAIN_BINARIES = {
   [DEFAULT_HOLOCHAIN_VERSION]: path.join(
     BINARIES_DIRECTORY,
-    `holochain-v${DEFAULT_HOLOCHAIN_VERSION}${process.platform === 'win32' ? '.exe' : ''}`,
+    `holochain-v${DEFAULT_HOLOCHAIN_VERSION}${packageJSON.name.replace('holochain', '')}${process.platform === 'win32' ? '.exe' : ''}`,
   ),
 };
 
 const LAIR_BINARY = path.join(
   BINARIES_DIRECTORY,
-  `lair-keystore-v${DEFAULT_LAIR_KEYSTORE_VERSION}${process.platform === 'win32' ? '.exe' : ''}`,
+  `lair-keystore-v${DEFAULT_LAIR_KEYSTORE_VERSION}${packageJSON.name.replace('holochain', '')}${process.platform === 'win32' ? '.exe' : ''}`,
 );
 
 const checkHolochainLairBinariesExist = () =>


### PR DESCRIPTION
* renames app to `holochain-launcher-0.4` (needs to be changed for the 0.300.0 release)
* adds an appendix to the holochain and lair binary names to prevent [name clashes](https://github.com/holochain/launcher/issues/218) when installing via .deb files