### PR TITLE
key generation and importing locked seed into lair working

### DIFF
--- a/rust-utils/index.d.ts
+++ b/rust-utils/index.d.ts
@@ -8,6 +8,18 @@ export function defaultConductorConfig(adminPort: number, keystoreConnectionUrl:
 export function decodeHappOrWebhapp(happOrWebhappBytes: Array<number>): Promise<HappAndUiBytes>
 export function readAndDecodeHappOrWebhapp(path: string): Promise<HappAndUiBytes>
 export function saveWebhapp(path: string, uiTargetDir: string): Promise<string>
+export interface KeyFile {
+  rootSeed: string
+  revocationKey: string
+  deviceKey: string
+  timestamp: number
+}
+/**
+ * Generates root seed, revocation key and device seed
+ *
+ * Use a single passphrase for the whole file for starters
+ */
+export function generateSeeds(passphrase: string): Promise<KeyFile>
 export interface ZomeCallUnsignedNapi {
   cellId: Array<Array<number>>
   zomeName: string
@@ -38,5 +50,6 @@ export class LauncherLairClient {
   constructor()
   static connect(connectionUrl: string, passphrase: string): Promise<LauncherLairClient>
   signZomeCall(zomeCallUnsignedJs: ZomeCallUnsignedNapi): Promise<ZomeCallNapi>
+  importLockedSeedBundle(importLockedSeedBundle: string, passphrase: string, tag: string): Promise<string>
   deriveAndImportSeedFromJsonFile(path: string): Promise<string>
 }

--- a/rust-utils/index.js
+++ b/rust-utils/index.js
@@ -252,11 +252,12 @@ if (!nativeBinding) {
   throw new Error(`Failed to load native binding`)
 }
 
-const { overwriteConfig, defaultConductorConfig, decodeHappOrWebhapp, readAndDecodeHappOrWebhapp, saveWebhapp, LauncherLairClient } = nativeBinding
+const { overwriteConfig, defaultConductorConfig, decodeHappOrWebhapp, readAndDecodeHappOrWebhapp, saveWebhapp, generateSeeds, LauncherLairClient } = nativeBinding
 
 module.exports.overwriteConfig = overwriteConfig
 module.exports.defaultConductorConfig = defaultConductorConfig
 module.exports.decodeHappOrWebhapp = decodeHappOrWebhapp
 module.exports.readAndDecodeHappOrWebhapp = readAndDecodeHappOrWebhapp
 module.exports.saveWebhapp = saveWebhapp
+module.exports.generateSeeds = generateSeeds
 module.exports.LauncherLairClient = LauncherLairClient

--- a/rust-utils/src/key_generation.rs
+++ b/rust-utils/src/key_generation.rs
@@ -52,12 +52,7 @@ pub async fn generate_seeds(passphrase: String) -> napi::Result<KeyFile> {
         .await
         .map_err(|e| napi::Error::from_reason(format!("Failed to derive device key: {}", e)))?;
 
-    // print public key to later check that it has been installed correctly into lairs
-    let device_pub_key = device_key.get_sign_pub_key().read_lock().to_vec();
-    let device_pub_key_b64 = base64::encode(device_pub_key);
-    println!("Device public key: {}", device_pub_key_b64);
-
-    let device_key_encrypted = revocation_key
+    let device_key_encrypted = device_key
         .lock()
         .add_pwhash_cipher(passphrase.as_bytes().to_owned())
         .lock()

--- a/rust-utils/src/key_generation.rs
+++ b/rust-utils/src/key_generation.rs
@@ -1,0 +1,84 @@
+use hc_seed_bundle::UnlockedSeedBundle;
+use std::time::SystemTime;
+
+
+#[napi(object)]
+pub struct KeyFile {
+    pub root_seed: String,
+    pub revocation_key: String,
+    pub device_key: String,
+    pub timestamp: f64,
+}
+
+/// Generates root seed, revocation key and device seed
+///
+/// Use a single passphrase for the whole file for starters
+#[napi]
+pub async fn generate_seeds(passphrase: String) -> napi::Result<KeyFile> {
+    // Generate, encrypt and base64 encode root seed
+    let root_seed = UnlockedSeedBundle::new_random()
+        .await
+        .map_err(|e| napi::Error::from_reason(format!("Failed to generate random seed: {}", e)))?;
+
+
+    let root_seed_encrypted = root_seed
+        .lock()
+        .add_pwhash_cipher(passphrase.as_bytes().to_owned())
+        .lock()
+        .await
+        .map_err(|e| napi::Error::from_reason(format!("Failed to encrypt root seed: {}", e)))?;
+
+    let root_seed_b64 = base64::encode(root_seed_encrypted);
+
+    // Derive, encrypt and base64 encode revocation key
+    let revocation_key = root_seed
+        .derive(0)
+        .await
+        .map_err(|e| napi::Error::from_reason(format!("Failed to derive revocation key: {}", e)))?;
+
+    let revocation_key_encrypted = revocation_key
+        .lock()
+        .add_pwhash_cipher(passphrase.as_bytes().to_owned())
+        .lock()
+        .await
+        .map_err(|e| napi::Error::from_reason(format!("Failed to encrypt root seed: {}", e)))?;
+
+    let revocation_key_b64 = base64::encode(revocation_key_encrypted);
+
+    // Derive, encrypt and base64 encode device key
+
+    let device_key = root_seed
+        .derive(1)
+        .await
+        .map_err(|e| napi::Error::from_reason(format!("Failed to derive device key: {}", e)))?;
+
+    // print public key to later check that it has been installed correctly into lairs
+    let device_pub_key = device_key.get_sign_pub_key().read_lock().to_vec();
+    let device_pub_key_b64 = base64::encode(device_pub_key);
+    println!("Device public key: {}", device_pub_key_b64);
+
+    let device_key_encrypted = revocation_key
+        .lock()
+        .add_pwhash_cipher(passphrase.as_bytes().to_owned())
+        .lock()
+        .await
+        .map_err(|e| napi::Error::from_reason(format!("Failed to encrypt root seed: {}", e)))?;
+
+    let device_key_b64 = base64::encode(device_key_encrypted);
+
+
+    let timestamp = SystemTime::now()
+        .duration_since(SystemTime::UNIX_EPOCH)
+        .map_err(|e| {
+            napi::Error::from_reason(format!("Failed to get system time since Unix epoch: {}", e))
+        })?;
+
+
+
+    Ok(KeyFile {
+        root_seed: root_seed_b64,
+        revocation_key: revocation_key_b64,
+        device_key: device_key_b64,
+        timestamp: timestamp.as_secs_f64(),
+    })
+}

--- a/rust-utils/src/launcher_lair_client.rs
+++ b/rust-utils/src/launcher_lair_client.rs
@@ -227,7 +227,7 @@ impl LauncherLairClient {
         // Get or generate key for encryption of the seed
         let encryption_key = match self.lair_client.get_entry(tag.into()).await {
             Ok(key) => match key {
-                LairEntryInfo::Seed { tag: _, seed_info } => seed_info,
+                LairEntryInfo::Seed { seed_info, .. } => seed_info,
                 _ => {
                     return Err(napi::Error::from_reason(
                         "The import encryption key in lair is of the wrong format.",

--- a/rust-utils/src/lib.rs
+++ b/rust-utils/src/lib.rs
@@ -3,6 +3,7 @@ extern crate napi_derive;
 
 pub mod conductor_config;
 pub mod decode_webapp;
+pub mod key_generation;
 pub mod types;
 mod utils;
 pub mod launcher_lair_client;

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -381,19 +381,6 @@ async function handleLaunch(password: string, isDirectLaunch = true) {
     DEFAULT_LAIR_CLIENT = await rustUtils.LauncherLairClient.connect(lairUrl, password);
   }
 
-  // Generate seed pair and log it
-  const seedFile = await rustUtils.generateSeeds('test');
-  console.log('\n\n###################\nGenerated seed file: ', seedFile);
-
-  // import device seed into lair
-  console.log('\n\n###################\nImporting device seed into lair.');
-  const importedPubkeyB64 = await DEFAULT_LAIR_CLIENT?.importLockedSeedBundle(
-    seedFile.deviceKey,
-    'test',
-    'hello2',
-  );
-  console.log('\n\n###################\nImported device seed with public key: ', importedPubkeyB64);
-
   LAUNCHER_EMITTER.emit(LOADING_PROGRESS_UPDATE, 'startingHolochain');
 
   if (!PRIVILEDGED_LAUNCHER_WINDOWS)

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -381,6 +381,19 @@ async function handleLaunch(password: string, isDirectLaunch = true) {
     DEFAULT_LAIR_CLIENT = await rustUtils.LauncherLairClient.connect(lairUrl, password);
   }
 
+  // Generate seed pair and log it
+  const seedFile = await rustUtils.generateSeeds('test');
+  console.log('\n\n###################\nGenerated seed file: ', seedFile);
+
+  // import device seed into lair
+  console.log('\n\n###################\nImporting device seed into lair.');
+  const importedPubkeyB64 = await DEFAULT_LAIR_CLIENT?.importLockedSeedBundle(
+    seedFile.deviceKey,
+    'test',
+    'hello2',
+  );
+  console.log('\n\n###################\nImported device seed with public key: ', importedPubkeyB64);
+
   LAUNCHER_EMITTER.emit(LOADING_PROGRESS_UPDATE, 'startingHolochain');
 
   if (!PRIVILEDGED_LAUNCHER_WINDOWS)


### PR DESCRIPTION
This PR adds two Rust methods to generate a new set of root seed revocation key and device seed as well as import a locked seed into lair given the password.