### PR TITLE
fix window open behavior on Windows, add frame on Linux

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -8,7 +8,7 @@ import { AppstoreAppClient, DevhubAppClient, webhappToHappAndUi } from 'appstore
 import { type ChildProcessWithoutNullStreams, spawnSync } from 'child_process';
 import { Command, Option } from 'commander';
 import type { BrowserWindow, IpcMainInvokeEvent } from 'electron';
-import { app, dialog, ipcMain, Menu, protocol } from 'electron';
+import { app, dialog, globalShortcut, ipcMain, Menu, protocol } from 'electron';
 import contextMenu from 'electron-context-menu';
 import { createIPCHandler } from 'electron-trpc/main';
 import fs from 'fs';
@@ -19,6 +19,7 @@ import semver from 'semver';
 import z from 'zod';
 
 import {
+  ANIMATION_DURATION,
   APP_STORE_APP_ID,
   DEVHUB_APP_ID,
   DISTRIBUTION_TYPE_DEFAULT_APP,
@@ -213,6 +214,8 @@ const HOLOCHAIN_MANAGERS: Record<string, HolochainManager> = {}; // holochain ma
 let LAIR_HANDLE: ChildProcessWithoutNullStreams | undefined;
 let PRIVILEDGED_LAUNCHER_WINDOWS: Record<Screen, BrowserWindow>; // Admin windows with special zome call signing priviledges
 const WINDOW_INFO_MAP: WindowInfoRecord = {}; // WindowInfo by webContents.id - used to verify origin of zome call requests
+let IS_LAUNCHED = false;
+let IS_QUITTING = false;
 
 const APP_CLIENTS: Record<InstalledAppId, AppClient> = {};
 let APPSTORE_APP_CLIENT: AppstoreAppClient | undefined;
@@ -264,6 +267,39 @@ app.whenReady().then(async () => {
 
   PRIVILEDGED_LAUNCHER_WINDOWS = setupAppWindows(LAUNCHER_EMITTER);
 
+  const mainWindow = PRIVILEDGED_LAUNCHER_WINDOWS[MAIN_SCREEN];
+  const settingsWindow = PRIVILEDGED_LAUNCHER_WINDOWS[SETTINGS_SCREEN];
+  mainWindow.on('close', (e) => {
+    // If launcher has already launched, i.e. not "Enter Password" screen anymore, only hide the window
+    if (!IS_QUITTING) {
+      if (IS_LAUNCHED) {
+        e.preventDefault();
+        mainWindow.hide();
+      } else {
+        // Close all windows to have the 'window-all-close' event be triggered
+        settingsWindow.close();
+      }
+    }
+  });
+
+  settingsWindow.on('close', (e) => {
+    if (!IS_QUITTING && IS_LAUNCHED) {
+      e.preventDefault();
+      LAUNCHER_EMITTER.emit(HIDE_SETTINGS_WINDOW, true);
+      settingsWindow.hide();
+      setTimeout(() => {
+        mainWindow.show();
+      }, ANIMATION_DURATION);
+    }
+  });
+
+  // make sure window objects get deleted after closing
+  Object.entries(PRIVILEDGED_LAUNCHER_WINDOWS).forEach(([key, window]) => {
+    window.on('closed', () => {
+      delete PRIVILEDGED_LAUNCHER_WINDOWS[key];
+    });
+  });
+
   createIPCHandler({ router, windows: Object.values(PRIVILEDGED_LAUNCHER_WINDOWS) });
 
   ipcMain.handle('sign-zome-call', handleSignZomeCall);
@@ -301,19 +337,24 @@ app.whenReady().then(async () => {
   }
 });
 
+app.on('before-quit', () => {
+  IS_QUITTING = true;
+});
+
 // Quit when all windows are closed, except on macOS. There, it's common
 // for applications and their menu bar to stay active until the user quits
 // explicitly with Cmd + Q.
 app.on('window-all-closed', () => {
+  app.quit();
   // if (process.platform !== 'darwin') {
   //   app.quit();
   // }
 });
 
-// app.on('will-quit', (e: Event) => {
-//   // let the launcher run in the background (systray)
-//   // e.preventDefault();
-// })
+app.on('will-quit', () => {
+  // Unregister all shortcuts.
+  globalShortcut.unregisterAll();
+});
 
 app.on('quit', () => {
   if (LAIR_HANDLE) {
@@ -425,6 +466,8 @@ async function handleLaunch(password: string, isDirectLaunch = true) {
       }),
     ),
   );
+
+  IS_LAUNCHED = true;
 
   if (isDirectLaunch) {
     PRIVILEDGED_LAUNCHER_WINDOWS[MAIN_SCREEN].setSize(WINDOW_SIZE, MIN_HEIGH, true);

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -270,27 +270,26 @@ app.whenReady().then(async () => {
   const mainWindow = PRIVILEDGED_LAUNCHER_WINDOWS[MAIN_SCREEN];
   const settingsWindow = PRIVILEDGED_LAUNCHER_WINDOWS[SETTINGS_SCREEN];
   mainWindow.on('close', (e) => {
+    if (IS_QUITTING) return;
     // If launcher has already launched, i.e. not "Enter Password" screen anymore, only hide the window
-    if (!IS_QUITTING) {
-      if (IS_LAUNCHED) {
-        e.preventDefault();
-        mainWindow.hide();
-      } else {
-        // Close all windows to have the 'window-all-close' event be triggered
-        settingsWindow.close();
-      }
+    if (IS_LAUNCHED) {
+      e.preventDefault();
+      mainWindow.hide();
+      return;
     }
+    // Close all windows to have the 'window-all-close' event be triggered
+    settingsWindow.close();
   });
 
   settingsWindow.on('close', (e) => {
-    if (!IS_QUITTING && IS_LAUNCHED) {
-      e.preventDefault();
-      LAUNCHER_EMITTER.emit(HIDE_SETTINGS_WINDOW, true);
-      settingsWindow.hide();
-      setTimeout(() => {
-        mainWindow.show();
-      }, ANIMATION_DURATION);
-    }
+    if (IS_QUITTING || !IS_LAUNCHED) return;
+
+    e.preventDefault();
+    LAUNCHER_EMITTER.emit(HIDE_SETTINGS_WINDOW, true);
+    settingsWindow.hide();
+    setTimeout(() => {
+      mainWindow.show();
+    }, ANIMATION_DURATION);
   });
 
   // make sure window objects get deleted after closing


### PR DESCRIPTION
This PR addresses https://github.com/holochain/launcher/issues/170

The problem was that by re-adding the window frame on Windows, the window could be closed for good (i.e. not just hidden) and then when trying to re-open it via the systray, the corresponding BrowserWindow object would not exist anymore.

This PR solves that problem in that it intercepts the 'close' event of the main window and only actually closes it if either launcher has not fully launched yet (e.g. still on the password screen), in which case it will also close the settings window to get the 'window-all-closed' event triggered and quit the app fully, or the app is quitting. Otherwise, the window will only be hidden instead of closed.