### PR TITLE
Fetch happ and UI in smallest possible chunks

### DIFF
--- a/libs/appstore/src/appstore/appstore-app-client.ts
+++ b/libs/appstore/src/appstore/appstore-app-client.ts
@@ -223,7 +223,7 @@ export class AppstoreAppClient {
         // const webappEntryHash = await this.appstoreZomeClient.hashWebappEntry(
         //   webappEntryEntity.content,
         // );
-        // if (webappEntryHash.toString() !== webappPackageVersion.webapp.toString()) {
+        // if (encodeHashToBase64(webappEntryHash) !== encodeHashToBase64(webappPackageVersion.webapp)) {
         //   throw new Error('Hash of received WebappEntry does not match the requested hash.');
         // }
 
@@ -329,7 +329,9 @@ export class AppstoreAppClient {
         const webappEntryHash = await this.appstoreZomeClient.hashWebappEntry(
           webappEntryEntity.content,
         );
-        if (webappEntryHash.toString() !== webappPackageVersion.webapp.toString()) {
+        if (
+          encodeHashToBase64(webappEntryHash) !== encodeHashToBase64(webappPackageVersion.webapp)
+        ) {
           throw new Error('Hash of received WebappEntry does not match the expected hash.');
         }
 
@@ -427,7 +429,9 @@ export class AppstoreAppClient {
         const webappEntryHash = await this.appstoreZomeClient.hashWebappEntry(
           webappEntryEntity.content,
         );
-        if (webappEntryHash.toString() !== webappPackageVersion.webapp.toString()) {
+        if (
+          encodeHashToBase64(webappEntryHash) !== encodeHashToBase64(webappPackageVersion.webapp)
+        ) {
           throw new Error('Hash of received WebappEntry does not match the expected hash.');
         }
 
@@ -536,7 +540,9 @@ export class AppstoreAppClient {
         const webappEntryHash = await this.appstoreZomeClient.hashWebappEntry(
           webappEntryEntity.content,
         );
-        if (webappEntryHash.toString() !== webappPackageVersion.webapp.toString()) {
+        if (
+          encodeHashToBase64(webappEntryHash) !== encodeHashToBase64(webappPackageVersion.webapp)
+        ) {
           throw new Error('Hash of received WebappEntry does not match the expected hash.');
         }
 
@@ -641,7 +647,9 @@ export class AppstoreAppClient {
         const webappEntryHash = await this.appstoreZomeClient.hashWebappEntry(
           webappEntryEntity.content,
         );
-        if (webappEntryHash.toString() !== webappPackageVersion.webapp.toString()) {
+        if (
+          encodeHashToBase64(webappEntryHash) !== encodeHashToBase64(webappPackageVersion.webapp)
+        ) {
           throw new Error('Hash of received WebappEntry does not match the expected hash.');
         }
 

--- a/libs/appstore/src/appstore/zomes/appstore-zome-client.ts
+++ b/libs/appstore/src/appstore/zomes/appstore-zome-client.ts
@@ -7,11 +7,14 @@ import {
 
 import type {
   DevhubAppEntry,
+  DnaEntry,
   Entity,
   UiEntry,
   WebAppEntry,
   WebAppPackageVersionEntry,
+  ZomeEntry,
 } from '../../devhub/types';
+import type { MemoryBlockEntry, MemoryEntry } from '../../mere-memory';
 import type { UpdateEntityInput } from '../../types';
 import { ZomeClient } from '../../zome-client/zome-client';
 import type {
@@ -123,6 +126,22 @@ export class AppstoreZomeClient extends ZomeClient {
 
   async hashUiEntry(input: UiEntry): Promise<EntryHash> {
     return this.callZome('hash_ui_entry', input);
+  }
+
+  async hashDnaEntry(input: DnaEntry): Promise<EntryHash> {
+    return this.callZome('hash_dna_entry', input);
+  }
+
+  async hashZomeEntry(input: ZomeEntry): Promise<EntryHash> {
+    return this.callZome('hash_zome_entry', input);
+  }
+
+  async hashMereMemoryBlockEntry(input: MemoryBlockEntry) {
+    return this.callZome('hash_mere_memory_block_entry', input);
+  }
+
+  async hashMereMemoryEntry(input: MemoryEntry) {
+    return this.callZome('hash_mere_memory_entry', input);
   }
 
   // async verifyWebappAsset(webappAsset: WebAppAsset, expectedHash: EntryHash): Promise<void> {

--- a/libs/appstore/src/appstore/zomes/appstore-zome-client.ts
+++ b/libs/appstore/src/appstore/zomes/appstore-zome-client.ts
@@ -147,7 +147,7 @@ export class AppstoreZomeClient extends ZomeClient {
   // async verifyWebappAsset(webappAsset: WebAppAsset, expectedHash: EntryHash): Promise<void> {
   //   // We recursively check that all hashes match, starting with the hash of the WebAppEntry
   //   const webappEntryHash = await this.hashWebappEntry(webappAsset.webapp_entry);
-  //   if (webappEntryHash.toString() !== expectedHash.toString())
+  //   if (encodeHashToBase64(webappEntryHash) !== encodeHashToBase64(expectedHash))
   //     throw new Error('WebAppEntry hash is invalid.');
   //   // verify AppAsset
   //   await this.verifyAppAsset(
@@ -160,7 +160,7 @@ export class AppstoreZomeClient extends ZomeClient {
 
   // async verifyUiAsset(uiAsset: UiAsset, expectedHash: EntryHash): Promise<void> {
   //   const uiEntryHash = await this.hashUiEntry(uiAsset.ui_entry);
-  //   if (uiEntryHash.toString() !== expectedHash.toString())
+  //   if (encodeHashToBase64(uiEntryHash) !== encodeHashToBase64(expectedHash))
   //     throw new Error('UiEntry hash is invalid.');
 
   //   uiAsset.ui_entry.mere_memory_addr
@@ -168,7 +168,7 @@ export class AppstoreZomeClient extends ZomeClient {
 
   // async verifyAppAsset(appAsset: AppAsset, expectedHash: EntryHash): Promise<void> {
   //   const appEntryHash = this.hashAppEntry(appAsset.app_entry);
-  //   if (appEntryHash.toString() !== expectedHash.toString())
+  //   if (encodeHashToBase64(appEntryHash) !== encodeHashToBase64(expectedHash))
   //     throw new Error('AppEntry hash is invalid.');
 
   //   if (appAsset.app_entry.manifest.roles.length !== Object.keys(appAsset.dna_assets).length)

--- a/libs/appstore/src/devhub/zomes/dnahub-zome-client.ts
+++ b/libs/appstore/src/devhub/zomes/dnahub-zome-client.ts
@@ -22,7 +22,7 @@ export class DnaHubZomeClient extends ZomeClient {
   }
 
   async createDnaEntry(input: DnaEntryInput): Promise<Entity<DnaEntry>> {
-    return this.callZome('create_dna', input);
+    return this.callZome('create_dna_entry', input);
   }
 
   async deriveDnaToken(input: CreateDnaInput): Promise<DnaToken> {

--- a/libs/appstore/src/portal/zomes/portal-zome-client.ts
+++ b/libs/appstore/src/portal/zomes/portal-zome-client.ts
@@ -1,4 +1,4 @@
-import { type AgentPubKey } from '@holochain/client';
+import { type AgentPubKey, encodeHashToBase64 } from '@holochain/client';
 
 import type { CustomRemoteCallInput, HostAvailability, HostEntry } from '../../appstore/types';
 import type { Entity } from '../../devhub/types';
@@ -134,7 +134,7 @@ export class PortalZomeClient extends ZomeClient {
       pingTimeout,
     );
 
-    console.log('got quickest host: ', quickestHost);
+    console.log('got quickest host: ', encodeHashToBase64(quickestHost));
     try {
       // console.log("@tryWithHosts: trying with first responding host: ", encodeHashToBase64(host));
       const result = await fn(quickestHost);

--- a/libs/appstore/src/portal/zomes/portal-zome-client.ts
+++ b/libs/appstore/src/portal/zomes/portal-zome-client.ts
@@ -150,7 +150,7 @@ export class PortalZomeClient extends ZomeClient {
       const pingResult = await this.getVisibleHostsForZomeFunction(dnaZomeFunction, pingTimeout);
 
       const otherAvailableHosts = pingResult.responded.filter(
-        (host) => host.toString() !== quickestHost.toString(),
+        (host) => encodeHashToBase64(host) !== encodeHashToBase64(quickestHost),
       );
 
       // console.log("@tryWithHosts: other available hosts: ", availableHosts.map((hash) => encodeHashToBase64(hash)));

--- a/libs/appstore/src/portal/zomes/portal-zome-client.ts
+++ b/libs/appstore/src/portal/zomes/portal-zome-client.ts
@@ -49,10 +49,10 @@ export class PortalZomeClient extends ZomeClient {
         const availableHost = await Promise.any(
           hosts.map(async (hostEntryEntity) => {
             const hostPubKey = hostEntryEntity.content.author;
-            // console.log(
-            //   '@getAvailableHostForZomeFunction: trying to ping host: ',
-            //   encodeHashToBase64(hostPubKey),
-            // );
+            console.log(
+              '@getAvailableHostForZomeFunction: trying to ping host: ',
+              encodeHashToBase64(hostPubKey),
+            );
 
             try {
               const result: Response<boolean> = await this.callZome('ping', hostPubKey, timeoutMs);
@@ -71,6 +71,7 @@ export class PortalZomeClient extends ZomeClient {
 
         return availableHost;
       } catch (e) {
+        console.error('Failed to find peer host: ', e);
         return Promise.reject('No available peer host found.');
       }
     } catch (e) {

--- a/libs/appstore/src/portal/zomes/portal-zome-client.ts
+++ b/libs/appstore/src/portal/zomes/portal-zome-client.ts
@@ -128,7 +128,7 @@ export class PortalZomeClient extends ZomeClient {
     statusCallback = () => {},
   }: TryWithHostsArgs<T>): Promise<T> {
     // try with first responding host
-    statusCallback('Getting available host...');
+    statusCallback('Searching available peer');
     const quickestHost: AgentPubKey = await this.getAvailableHostForZomeFunction(
       dnaZomeFunction,
       pingTimeout,
@@ -137,7 +137,7 @@ export class PortalZomeClient extends ZomeClient {
     console.log('got quickest host: ', encodeHashToBase64(quickestHost));
     try {
       // console.log("@tryWithHosts: trying with first responding host: ", encodeHashToBase64(host));
-      const result = await fn(quickestHost);
+      const result = await fn(quickestHost, statusCallback);
       return result;
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
     } catch (e: any) {
@@ -159,7 +159,7 @@ export class PortalZomeClient extends ZomeClient {
       for (const host of otherAvailableHosts) {
         try {
           // console.log("@tryWithHosts: retrying with other host: ", encodeHashToBase64(otherHost));
-          const response = await fn(host);
+          const response = await fn(host, statusCallback);
           return response;
           // eslint-disable-next-line @typescript-eslint/no-explicit-any
         } catch (e: any) {

--- a/libs/appstore/src/types.ts
+++ b/libs/appstore/src/types.ts
@@ -14,7 +14,7 @@ export type DnaZomeFunction = {
 };
 
 export type TryWithHostsArgs<T> = {
-  fn: (host: AgentPubKey) => Promise<T>;
+  fn: (host: AgentPubKey, statusCallback: (status: string) => void) => Promise<T>;
   dnaZomeFunction: DnaZomeFunction;
   pingTimeout?: number;
   statusCallback?: (status: string) => void;

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -608,16 +608,32 @@ const router = t.router({
     if (isHappAvailable && isUiAvailable) return;
 
     try {
-      if (isHappAvailable && !isUiAvailable) {
-        const uiBytes = await appstoreAppClient.fetchUiBytes(appVersionEntry);
-        holochainManager.storeUiIfNecessary(Array.from(uiBytes), icon);
-        return;
-      }
+      console.log('Awaiting promises...');
+      await Promise.allSettled(
+        [isHappAvailable, isUiAvailable].map(async (_) => {
+          if (!isHappAvailable) {
+            console.log('fetching happ bytes...');
+            const happBytes = await appstoreAppClient.fetchHappBytes(appVersionEntry);
+            holochainManager.storeHapp(Array.from(happBytes));
+          }
+          if (!isUiAvailable) {
+            console.log('fetching UI bytes...');
+            const uiBytes = await appstoreAppClient.fetchUiBytes(appVersionEntry);
+            holochainManager.storeUiIfNecessary(Array.from(uiBytes), icon);
+          }
+        }),
+      );
 
-      const webhappBytes = await appstoreAppClient.fetchWebappBytes(appVersionEntry);
-      const { ui, happ } = webhappToHappAndUi(webhappBytes);
-      holochainManager.storeUiIfNecessary(Array.from(ui), icon);
-      holochainManager.storeHapp(Array.from(happ));
+      // if (isHappAvailable && !isUiAvailable) {
+      //   const uiBytes = await appstoreAppClient.fetchUiBytes(appVersionEntry);
+      //   holochainManager.storeUiIfNecessary(Array.from(uiBytes), icon);
+      //   return;
+      // }
+
+      // const webhappBytes = await appstoreAppClient.fetchWebappBytes(appVersionEntry);
+      // const { ui, happ } = webhappToHappAndUi(webhappBytes);
+      // holochainManager.storeUiIfNecessary(Array.from(ui), icon);
+      // holochainManager.storeHapp(Array.from(happ));
     } catch (error) {
       const errorMessage = getErrorMessage(error);
       if (errorMessage.includes('No available peer host found.')) {

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -609,7 +609,6 @@ const router = t.router({
     if (isHappAvailable && isUiAvailable) return;
 
     try {
-      console.log('Awaiting promises (in sequence)...');
       if (!isHappAvailable) {
         console.log('fetching happ bytes...');
         const happBytes = await appstoreAppClient.fetchHappBytesInChunks(appVersionEntry);
@@ -622,17 +621,6 @@ const router = t.router({
         holochainManager.storeUiIfNecessary(Array.from(uiBytes), icon);
         console.log('UI stored.');
       }
-
-      // if (isHappAvailable && !isUiAvailable) {
-      //   const uiBytes = await appstoreAppClient.fetchUiBytes(appVersionEntry);
-      //   holochainManager.storeUiIfNecessary(Array.from(uiBytes), icon);
-      //   return;
-      // }
-
-      // const webhappBytes = await appstoreAppClient.fetchWebappBytes(appVersionEntry);
-      // const { ui, happ } = webhappToHappAndUi(webhappBytes);
-      // holochainManager.storeUiIfNecessary(Array.from(ui), icon);
-      // holochainManager.storeHapp(Array.from(happ));
     } catch (error) {
       console.error(error);
       const errorMessage = getErrorMessage(error);

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -56,6 +56,7 @@ import {
   NO_DEVHUB_AUTHENTICATION_TOKEN_FOUND,
   NO_RUNNING_HOLOCHAIN_MANAGER_ERROR,
   REFETCH_DATA_IN_ALL_WINDOWS,
+  REMOTE_CALL_TIMEOUT_ERROR,
   UpdateUiFromHashSchema,
   WRONG_INSTALLED_APP_STRUCTURE,
 } from '$shared/types';
@@ -608,26 +609,20 @@ const router = t.router({
     if (isHappAvailable && isUiAvailable) return;
 
     try {
-      console.log('Awaiting promises...');
-      await Promise.allSettled([
-        (async () => {
-          if (!isHappAvailable) {
-            console.log('fetching happ bytes...');
-            const happBytes = await appstoreAppClient.fetchHappBytes(appVersionEntry);
-            holochainManager.storeHapp(Array.from(happBytes));
-            console.log('happ stored.');
-          }
-        })(),
-        (async () => {
-          if (!isUiAvailable) {
-            console.log('fetching UI bytes...');
-            const uiBytes = await appstoreAppClient.fetchUiBytes(appVersionEntry);
-            holochainManager.storeUiIfNecessary(Array.from(uiBytes), icon);
-            console.log('UI stored.');
-          }
-          return;
-        })(),
-      ]);
+      console.log('Awaiting promises (in sequence)...');
+      if (!isHappAvailable) {
+        console.log('fetching happ bytes...');
+        const happBytes = await appstoreAppClient.fetchHappBytes(appVersionEntry);
+        holochainManager.storeHapp(Array.from(happBytes));
+        console.log('happ stored.');
+      }
+      if (!isUiAvailable) {
+        console.log('fetching UI bytes...');
+        const uiBytes = await appstoreAppClient.fetchUiBytes(appVersionEntry);
+        holochainManager.storeUiIfNecessary(Array.from(uiBytes), icon);
+        console.log('UI stored.');
+      }
+
       // if (isHappAvailable && !isUiAvailable) {
       //   const uiBytes = await appstoreAppClient.fetchUiBytes(appVersionEntry);
       //   holochainManager.storeUiIfNecessary(Array.from(uiBytes), icon);
@@ -639,11 +634,17 @@ const router = t.router({
       // holochainManager.storeUiIfNecessary(Array.from(ui), icon);
       // holochainManager.storeHapp(Array.from(happ));
     } catch (error) {
-      console.error('E R R O R  ! !');
+      console.error(error);
       const errorMessage = getErrorMessage(error);
       if (errorMessage.includes('No available peer host found.')) {
         return throwTRPCErrorError({
           message: NO_AVAILABLE_PEER_HOSTS_ERROR,
+          cause: errorMessage,
+        });
+      }
+      if (errorMessage.includes('Request timed out in 60000 ms: call_zome')) {
+        return throwTRPCErrorError({
+          message: REMOTE_CALL_TIMEOUT_ERROR,
           cause: errorMessage,
         });
       }

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -612,7 +612,7 @@ const router = t.router({
       console.log('Awaiting promises (in sequence)...');
       if (!isHappAvailable) {
         console.log('fetching happ bytes...');
-        const happBytes = await appstoreAppClient.fetchHappBytes(appVersionEntry);
+        const happBytes = await appstoreAppClient.fetchHappBytesInChunks(appVersionEntry);
         holochainManager.storeHapp(Array.from(happBytes));
         console.log('happ stored.');
       }

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -609,21 +609,25 @@ const router = t.router({
 
     try {
       console.log('Awaiting promises...');
-      await Promise.allSettled(
-        [isHappAvailable, isUiAvailable].map(async (_) => {
+      await Promise.allSettled([
+        (async () => {
           if (!isHappAvailable) {
             console.log('fetching happ bytes...');
             const happBytes = await appstoreAppClient.fetchHappBytes(appVersionEntry);
             holochainManager.storeHapp(Array.from(happBytes));
+            console.log('happ stored.');
           }
+        })(),
+        (async () => {
           if (!isUiAvailable) {
             console.log('fetching UI bytes...');
             const uiBytes = await appstoreAppClient.fetchUiBytes(appVersionEntry);
             holochainManager.storeUiIfNecessary(Array.from(uiBytes), icon);
+            console.log('UI stored.');
           }
-        }),
-      );
-
+          return;
+        })(),
+      ]);
       // if (isHappAvailable && !isUiAvailable) {
       //   const uiBytes = await appstoreAppClient.fetchUiBytes(appVersionEntry);
       //   holochainManager.storeUiIfNecessary(Array.from(uiBytes), icon);
@@ -635,6 +639,7 @@ const router = t.router({
       // holochainManager.storeUiIfNecessary(Array.from(ui), icon);
       // holochainManager.storeHapp(Array.from(happ));
     } catch (error) {
+      console.error('E R R O R  ! !');
       const errorMessage = getErrorMessage(error);
       if (errorMessage.includes('No available peer host found.')) {
         return throwTRPCErrorError({

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -618,7 +618,7 @@ const router = t.router({
       }
       if (!isUiAvailable) {
         console.log('fetching UI bytes...');
-        const uiBytes = await appstoreAppClient.fetchUiBytes(appVersionEntry);
+        const uiBytes = await appstoreAppClient.fetchUiBytesInChunks(appVersionEntry);
         holochainManager.storeUiIfNecessary(Array.from(uiBytes), icon);
         console.log('UI stored.');
       }

--- a/src/main/logs.ts
+++ b/src/main/logs.ts
@@ -51,24 +51,25 @@ export function setupLogs(
     lairLogger.log('info', logLine);
   });
   launcherEmitter.on(HOLOCHAIN_LOG, (holochainData) => {
-    logHolochain(holochainData as HolochainData, logFileTransport);
+    logHolochain(holochainData as HolochainData, logFileTransport, launcherFileSystem.profile);
   });
   launcherEmitter.on(HOLOCHAIN_ERROR, (holochainData) => {
-    logHolochain(holochainData as HolochainData, logFileTransport);
+    logHolochain(holochainData as HolochainData, logFileTransport, launcherFileSystem.profile);
   });
   launcherEmitter.on(WASM_LOG, (holochainData) => {
-    logHolochain(holochainData as HolochainData, logFileTransport);
+    logHolochain(holochainData as HolochainData, logFileTransport, launcherFileSystem.profile);
   });
 }
 
 function logHolochain(
   holochainData: HolochainData,
   logFileTransport: winston.transports.FileTransportInstance,
+  profile: string,
 ) {
   const holochainPartition = holochainData.holochainDataRoot.name;
   const identifier = identifierFromHolochainData(holochainData);
   const line = (holochainData as HolochainData).data;
-  const logLine = `[${identifier}]: ${line}`;
+  const logLine = `[${identifier}]${profile !== 'default' ? `[profile: ${profile}]` : ''}: ${line}`;
   console.log(logLine);
   let logger = HOLOCHAIN_LOGGERS[holochainPartition];
   if (logger) {

--- a/src/renderer/src/lib/helpers/display.ts
+++ b/src/renderer/src/lib/helpers/display.ts
@@ -75,6 +75,6 @@ export const filterAppsBySearchAndAllowlist = (
 	return apps.filter(
 		({ title, id }) =>
 			title.toLowerCase().includes(lowerCaseSearchInput) &&
-			allowlistKeys.some((key) => key.toString() === id.toString())
+			allowlistKeys.some((key) => encodeHashToBase64(key) === encodeHashToBase64(id))
 	);
 };

--- a/src/renderer/src/lib/locale/en/common.json
+++ b/src/renderer/src/lib/locale/en/common.json
@@ -28,6 +28,7 @@
 	"devhubInstalled": "DevHub installed",
 	"disabled": "Disabled",
 	"discoverInstallAndManageYourApps": "Discover, install and manage your apps",
+	"downloadError": "Download Error",
 	"enabled": "Enabled",
 	"enterAppName": "Enter app name",
 	"enterNetworkSeed": "Enter network seed",

--- a/src/renderer/src/lib/locale/en/errors.json
+++ b/src/renderer/src/lib/locale/en/errors.json
@@ -15,6 +15,7 @@
 	"noDevhubAuthenticationTokenFound": "No authentication token found for devhub",
 	"noPublishersAvailableError": "No publishers available",
 	"noRunningHolochainManagerError": "No running Holochain manager",
+	"remoteCallTimeoutError": "Remote request to peer timed out.",
 	"remoteOperationFailedError": "Remote operation failed. Please try again later.",
 	"wrongInstalledAppStructure": "Wrong installed app structure",
 	"wrongPassword": "Wrong password"

--- a/src/renderer/src/routes/(main)/app-store/[slug]/+page.svelte
+++ b/src/renderer/src/routes/(main)/app-store/[slug]/+page.svelte
@@ -53,7 +53,7 @@
 		}
 		return showModalError({
 			modalStore,
-			errorTitle: $i18n.t('appError'),
+			errorTitle: $i18n.t('downloadError'),
 			errorMessage: $i18n.t(errorMessage)
 		});
 	};

--- a/src/shared/types/errors.ts
+++ b/src/shared/types/errors.ts
@@ -14,6 +14,7 @@ export const NO_DEVHUB_AUTHENTICATION_TOKEN_FOUND = 'noDevhubAuthenticationToken
 export const NO_PUBLISHERS_AVAILABLE_ERROR = 'noPublishersAvailableError';
 export const NO_RUNNING_HOLOCHAIN_MANAGER_ERROR = 'noRunningHolochainManagerError';
 export const NO_AVAILABLE_PEER_HOSTS_ERROR = 'noAvailablePeerHostsError';
+export const REMOTE_CALL_TIMEOUT_ERROR = 'remoteCallTimeoutError';
 export const WRONG_INSTALLED_APP_STRUCTURE = 'wrongInstalledAppStructure';
 export const WRONG_PASSWORD = 'wrongPassword';
 


### PR DESCRIPTION
This PR changes to fetching UI and happ in the smallest possible chunks, each with independent remote calls in series to prevent zome call timeouts.