### PR TITLE
New window open logic

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -277,7 +277,6 @@ app.whenReady().then(async () => {
 
   PRIVILEDGED_LAUNCHER_WINDOWS[MAIN_WINDOW] = mainWindow;
 
-  const settingsWindow = PRIVILEDGED_LAUNCHER_WINDOWS[SETTINGS_WINDOW];
   mainWindow.on('close', (e) => {
     if (IS_QUITTING) return;
     // If launcher has already launched, i.e. not "Enter Password" screen anymore, only hide the window
@@ -286,6 +285,7 @@ app.whenReady().then(async () => {
       mainWindow.hide();
       return;
     }
+    const settingsWindow = PRIVILEDGED_LAUNCHER_WINDOWS[SETTINGS_WINDOW];
     // Close all windows to have the 'window-all-close' event be triggered
     if (settingsWindow) settingsWindow.close();
   });

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -534,10 +534,20 @@ const router = t.router({
     console.log('Requested open settings');
     let settingsWindow = PRIVILEDGED_LAUNCHER_WINDOWS[SETTINGS_WINDOW];
     if (settingsWindow) {
+      const mainWindow = PRIVILEDGED_LAUNCHER_WINDOWS[MAIN_WINDOW];
+      if (mainWindow) {
+        const [xMain, yMain] = mainWindow.getPosition();
+        settingsWindow.setPosition(xMain + 50, yMain + 50);
+      }
       settingsWindow.show();
     } else {
-      settingsWindow = createSettingsWindow();
+      const mainWindow = PRIVILEDGED_LAUNCHER_WINDOWS[MAIN_WINDOW];
+      const [xMain, yMain] = mainWindow.getPosition();
+
+      settingsWindow = createSettingsWindow(xMain + 50, yMain + 50);
       loadOrServe(settingsWindow, { screen: SETTINGS_WINDOW });
+
+      // https://github.com/electron/electron/issues/1836#issuecomment-677983707
 
       PRIVILEDGED_LAUNCHER_WINDOWS[SETTINGS_WINDOW] = settingsWindow;
       settingsWindow.show();

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -531,7 +531,6 @@ const getDevhubAppClient = async () => {
 
 const router = t.router({
   openSettings: t.procedure.mutation(() => {
-    console.log('Requested open settings');
     let settingsWindow = PRIVILEDGED_LAUNCHER_WINDOWS[SETTINGS_WINDOW];
     if (settingsWindow) {
       const mainWindow = PRIVILEDGED_LAUNCHER_WINDOWS[MAIN_WINDOW];

--- a/src/main/windows.ts
+++ b/src/main/windows.ts
@@ -53,11 +53,17 @@ const createAdminWindow = ({
   optWidth,
   frame = false,
   icon,
+  x,
+  y,
+  show,
 }: {
   title: string;
   optWidth?: number;
   frame?: boolean;
   icon?: Electron.NativeImage;
+  x?: number;
+  y?: number;
+  show?: boolean;
 }) =>
   new BrowserWindow({
     frame: frame,
@@ -67,7 +73,9 @@ const createAdminWindow = ({
     icon,
     minHeight: MIN_HEIGH,
     title: title,
-    show: false,
+    show,
+    x,
+    y,
     webPreferences: {
       preload: path.resolve(__dirname, '../preload/admin.js'),
     },
@@ -130,8 +138,12 @@ export const setupMainWindowAndTray = (launcherEmitter: LauncherEmitter): Browse
 
   globalShortcut.register('CommandOrControl+Shift+L', () => {
     if (mainWindow) {
-      mainWindow.setSize(WINDOW_SIZE, MIN_HEIGH);
-      mainWindow.show();
+      if (mainWindow.isFocused()) {
+        mainWindow.hide();
+      } else {
+        mainWindow.setSize(WINDOW_SIZE, MIN_HEIGH);
+        mainWindow.show();
+      }
     }
   });
 
@@ -142,7 +154,7 @@ export const setupMainWindowAndTray = (launcherEmitter: LauncherEmitter): Browse
   return mainWindow;
 };
 
-export const createSettingsWindow = (): BrowserWindow => {
+export const createSettingsWindow = (x?: number, y?: number): BrowserWindow => {
   // Create the browser window.
   const mainIcon = nativeImage.createFromPath(path.join(ICONS_DIRECTORY, '../icon.png'));
 
@@ -151,6 +163,9 @@ export const createSettingsWindow = (): BrowserWindow => {
     frame: true,
     optWidth: SETTINGS_SIZE,
     icon: mainIcon,
+    x,
+    y,
+    show: true,
   });
 
   return settingsWindow;

--- a/src/shared/types/launcher.ts
+++ b/src/shared/types/launcher.ts
@@ -12,7 +12,7 @@ import {
   type SETTINGS_WINDOW,
 } from '../const';
 
-export type Screen = typeof MAIN_WINDOW | typeof SETTINGS_WINDOW;
+export type AdminWindow = typeof MAIN_WINDOW | typeof SETTINGS_WINDOW;
 
 export const MainScreenRouteSchema = z.union([z.literal(APP_STORE), z.literal(APPS_VIEW)]);
 


### PR DESCRIPTION
This PR changes the logic around creating/opening/showing windows in the following way:
* the settings window is created independently from the main window
* if the settings window is opened from the main window, it will always show next to the main window, i.e. on the same screen
* the `CommandOrControl+Shift+L` shortcut now also closes the main window if the main window is already focused