### PR TITLE
Indicate duplicate app id

### DIFF
--- a/rust-utils/Cargo.lock
+++ b/rust-utils/Cargo.lock
@@ -2151,7 +2151,7 @@ dependencies = [
 
 [[package]]
 name = "hc-launcher-rust-utils"
-version = "0.201.0"
+version = "0.203.0"
 dependencies = [
  "base36",
  "base64 0.13.1",

--- a/rust-utils/Cargo.toml
+++ b/rust-utils/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 edition = "2021"
 name = "hc-launcher-rust-utils"
-version = "0.201.0"
+version = "0.203.0"
 
 [lib]
 crate-type = ["cdylib"]

--- a/rust-utils/package.json
+++ b/rust-utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hc-launcher-rust-utils",
-  "version": "0.202.1",
+  "version": "0.203.1",
   "main": "index.js",
   "types": "index.d.ts",
   "napi": {

--- a/src/renderer/src/lib/locale/en/common.json
+++ b/src/renderer/src/lib/locale/en/common.json
@@ -6,6 +6,7 @@
 	"addhApp": "Add a hApp",
 	"advanced": "Advanced",
 	"allowListLoading": "Loading verified apps",
+	"appIdAlreadyExists": "An App with this name already exists.",
 	"appDetailsUpdatedSuccessfully": "App details updated successfully",
 	"appError": "App Error",
 	"appSettings": "App Settings",

--- a/src/renderer/src/lib/modal/InputModal.svelte
+++ b/src/renderer/src/lib/modal/InputModal.svelte
@@ -6,6 +6,7 @@
 	export let id: string;
 	export let value: string | undefined;
 	export let placeholder = '';
+	export let invalidityMsg: string | undefined = undefined;
 
 	let input: Input;
 
@@ -18,27 +19,33 @@
 	const handleBlur = () => (isFocused = false);
 </script>
 
-<div class="relative">
-	<label for={id} class="absolute left-4 top-4 text-xs opacity-60">{label.toUpperCase()}</label>
-	<Input
-		bind:this={input}
-		bind:value
-		on:focus={handleFocus}
-		on:blur={handleBlur}
-		props={{
-			class: `px-20 input-modal pt-6 placeholder-white placeholder-semibold`,
-			id,
-			type: 'text',
-			placeholder: getPlaceholder(isFocused, placeholder)
-		}}
-	/>
-	<slot />
-	<button
-		type="button"
-		class="absolute right-4 top-3 !outline-none"
-		on:click={input.focusInput}
-		aria-label="Edit input"
-	>
-		<Edit />
-	</button>
+<div>
+	<div class="relative">
+		<label for={id} class="absolute left-4 top-4 text-xs opacity-60">{label.toUpperCase()}</label>
+		<Input
+			bind:this={input}
+			bind:value
+			on:focus={handleFocus}
+			on:blur={handleBlur}
+			props={{
+				class: `px-20 input-modal pt-6 placeholder-white placeholder-semibold`,
+				id,
+				type: 'text',
+				placeholder: getPlaceholder(isFocused, placeholder)
+			}}
+		/>
+		<slot />
+		<button
+			type="button"
+			class="absolute right-4 top-3 !outline-none"
+			on:click={input.focusInput}
+			aria-label="Edit input"
+		>
+			<Edit />
+		</button>
+	</div>
+	<div class="ml-5 text-sm mb-0 text-rose-600 {invalidityMsg ? '' : 'invisible'}">
+		{invalidityMsg}
+	</div>
 </div>
+

--- a/src/renderer/src/lib/modal/ModalInstallForm.svelte
+++ b/src/renderer/src/lib/modal/ModalInstallForm.svelte
@@ -45,7 +45,7 @@
 		}
 	};
 
-	$: duplicateAppId = $installedApps.data?.some((extendedAppInfo) => extendedAppInfo.appInfo.installed_app_id === formData.appId);
+	$: duplicateAppId = $installedApps.data?.some(({appInfo}) => appInfo.installed_app_id === formData.appId);
 
 	$: invalidityMsg = duplicateAppId ? $i18n.t('appIdAlreadyExists') : undefined;
 


### PR DESCRIPTION
Adds an error indicator below the App Id input field in the app install dialog if the chosen name is already in use by another app.