### PR TITLE
Feat/automatic updates UI

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -620,7 +620,7 @@ const getDevhubAppClient = async () => {
  */
 
 const router = t.router({
-  launcherUpdateAvailable: t.procedure.query(() => UPDATE_AVAILABLE),
+  launcherUpdateAvailable: t.procedure.query(() => UPDATE_AVAILABLE || null),
   installLauncherUpdate: t.procedure.mutation(async () => {
     if (!UPDATE_AVAILABLE) throw new Error('No update available.');
     // downloading means that with the next start of the application it's automatically going to be installed

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -239,7 +239,7 @@ let IS_QUITTING = false;
 const APP_CLIENTS: Record<InstalledAppId, AppClient> = {};
 let APPSTORE_APP_CLIENT: AppstoreAppClient | undefined;
 let DEVHUB_APP_CLIENT: DevhubAppClient | undefined;
-let UPDATE_AVAILABLE: LauncherUpdate | undefined;
+let UPDATE_AVAILABLE: LauncherUpdate | null = null;
 
 Menu.setApplicationMenu(launcherMenu(LAUNCHER_FILE_SYSTEM));
 

--- a/src/renderer/eslint.config.js
+++ b/src/renderer/eslint.config.js
@@ -17,7 +17,8 @@ export default [
 		},
 		rules: {
 			'simple-import-sort/imports': 'error',
-			'simple-import-sort/exports': 'error'
+			'simple-import-sort/exports': 'error',
+			'svelte/no-at-html-tags': 'allow'
 		},
 		ignores: ['.DS_Store', 'node_modules', '/.svelte-kit']
 	},

--- a/src/renderer/package.json
+++ b/src/renderer/package.json
@@ -12,6 +12,7 @@
 		"format": "prettier --write 'src/**/*.{js,ts,svelte,json,postcss}'"
 	},
 	"dependencies": {
+    "dompurify": "3.1.5",
 		"@floating-ui/dom": "^1.6.5",
     "@shoelace-style/shoelace": "2.15.1",
 		"@skeletonlabs/skeleton": "2.10.1",
@@ -19,8 +20,10 @@
 		"@tanstack/svelte-query": "^5.46.1",
 		"clsx": "^2.1.1",
 		"i18next": "^23.11.5",
+    "javascript-time-ago": "2.5.9",
 		"js-base64": "3.7.7",
 		"localforage": "^1.10.0",
+    "marked": "12.0.2",
 		"svelte": "^4.2.18",
 		"svelte-i18next": "^2.2.2",
 		"tailwindcss": "3.4.4"
@@ -31,6 +34,7 @@
 		"@sveltejs/vite-plugin-svelte": "^3.1.1",
 		"@tailwindcss/forms": "^0.5.7",
 		"@types/dom-view-transitions": "^1.0.4",
+    "@types/dompurify": "3.0.5",
 		"autoprefixer": "10.4.19",
 		"eslint-plugin-svelte": "^2.41.0",
 		"postcss": "8.4.38",

--- a/src/renderer/src/lib/const/menu.ts
+++ b/src/renderer/src/lib/const/menu.ts
@@ -1,3 +1,4 @@
+export const LAUNCHER_UPDATES = 'updates';
 export const SYSTEM_INFORMATION = 'systemInformation';
 export const SYSTEM_SETTINGS = 'systemSettings';
 export const KEY_MANAGEMENT = 'keyManagement';

--- a/src/renderer/src/lib/helpers/other.ts
+++ b/src/renderer/src/lib/helpers/other.ts
@@ -1,7 +1,9 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import { CellType, encodeHashToBase64 } from '@holochain/client';
 import type { AppstoreAppClient, AppVersionEntry, Entity } from 'appstore-tools';
+import DOMPurify from 'dompurify';
 import localforage from 'localforage';
+import { marked } from 'marked';
 
 import { MAX_IMAGE_WIDTH_AND_HEIGHT } from '$const';
 import { createAppStoreClient, createDevHubClient } from '$services';
@@ -236,3 +238,21 @@ export const resizeImage = async (file: File): Promise<Uint8Array | null> => {
 		}, 'image/png');
 	});
 };
+
+export function markdownParseSafe(input: string): string {
+	const markedData = marked.parse(input) as string;
+	return DOMPurify.sanitize(markedData);
+}
+
+export function markdownParseSafeTailwind(input: string): string {
+	const markedData = marked.parse(input) as string;
+	const htmlString = DOMPurify.sanitize(markedData);
+	return htmlString
+		.replaceAll('<ul>', '<ul class="list-disc ml-6">')
+		.replaceAll('<ol>', '<ol class="list-decimal ml-6">')
+		.replaceAll('<h1>', '<h1 class="h1">')
+		.replaceAll('<h2>', '<h1 class="h2">')
+		.replaceAll('<h3>', '<h1 class="h3">')
+		.replaceAll('<h4>', '<h1 class="h4">')
+		.replaceAll('<h5>', '<h1 class="h5">')
+}

--- a/src/renderer/src/lib/helpers/other.ts
+++ b/src/renderer/src/lib/helpers/other.ts
@@ -251,8 +251,8 @@ export function markdownParseSafeTailwind(input: string): string {
 		.replaceAll('<ul>', '<ul class="list-disc ml-6">')
 		.replaceAll('<ol>', '<ol class="list-decimal ml-6">')
 		.replaceAll('<h1>', '<h1 class="h1">')
-		.replaceAll('<h2>', '<h1 class="h2">')
-		.replaceAll('<h3>', '<h1 class="h3">')
-		.replaceAll('<h4>', '<h1 class="h4">')
-		.replaceAll('<h5>', '<h1 class="h5">')
+		.replaceAll('<h2>', '<h2 class="h2">')
+		.replaceAll('<h3>', '<h3 class="h3">')
+		.replaceAll('<h4>', '<h4 class="h4">')
+		.replaceAll('<h5>', '<h5 class="h5">')
 }

--- a/src/renderer/src/lib/icons/Menu-Info.svelte
+++ b/src/renderer/src/lib/icons/Menu-Info.svelte
@@ -5,9 +5,9 @@
 </script>
 
 <svg
-	width="20"
-	height="20"
-	viewBox="0 0 20 20"
+	width="24"
+	height="24"
+	viewBox="0 0 24 24"
 	class={fillColor}
 	xmlns="http://www.w3.org/2000/svg"
 >

--- a/src/renderer/src/lib/icons/Menu-Info.svelte
+++ b/src/renderer/src/lib/icons/Menu-Info.svelte
@@ -5,9 +5,9 @@
 </script>
 
 <svg
-	width="24"
-	height="24"
-	viewBox="0 0 24 24"
+	width="20"
+	height="20"
+	viewBox="0 0 20 20"
 	class={fillColor}
 	xmlns="http://www.w3.org/2000/svg"
 >

--- a/src/renderer/src/lib/icons/TrashCan.svelte
+++ b/src/renderer/src/lib/icons/TrashCan.svelte
@@ -1,9 +1,13 @@
 <script lang="ts">
-  export let color: string | undefined;
-  export let width = 20;
+	export let color: string | undefined;
+	export let width = 20;
 </script>
 
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill={color ? color : ''} style={`width: ${width}px`}
+<svg
+	xmlns="http://www.w3.org/2000/svg"
+	viewBox="0 0 24 24"
+	fill={color ? color : ''}
+	style={`width: ${width}px`}
 	><path
 		d="M9,3V4H4V6H5V19A2,2 0 0,0 7,21H17A2,2 0 0,0 19,19V6H20V4H15V3H9M7,6H17V19H7V6M9,8V17H11V8H9M13,8V17H15V8H13Z"
 	/></svg

--- a/src/renderer/src/lib/icons/Updates.svelte
+++ b/src/renderer/src/lib/icons/Updates.svelte
@@ -1,0 +1,12 @@
+<script>
+	import { NOT_SELECTED_ICON_STYLE } from '$const';
+
+	export let fillColor = NOT_SELECTED_ICON_STYLE;
+</script>
+
+<svg width="24" height="24" viewBox="0 0 24 24" class={fillColor} xmlns="http://www.w3.org/2000/svg"
+	><title>Updates</title><path
+		class={fillColor}
+		d="M19,1L17.74,3.75L15,5L17.74,6.26L19,9L20.25,6.26L23,5L20.25,3.75M9,4L6.5,9.5L1,12L6.5,14.5L9,20L11.5,14.5L17,12L11.5,9.5M19,15L17.74,17.74L15,19L17.74,20.25L19,23L20.25,20.25L23,19L20.25,17.74"
+	/></svg
+>

--- a/src/renderer/src/lib/icons/Updates.svelte
+++ b/src/renderer/src/lib/icons/Updates.svelte
@@ -4,7 +4,7 @@
 	export let fillColor = NOT_SELECTED_ICON_STYLE;
 </script>
 
-<svg width="24" height="24" viewBox="0 0 24 24" class={fillColor} xmlns="http://www.w3.org/2000/svg"
+<svg width="20" height="20" viewBox="0 0 24 24" class={fillColor} xmlns="http://www.w3.org/2000/svg"
 	><title>Updates</title><path
 		class={fillColor}
 		d="M19,1L17.74,3.75L15,5L17.74,6.26L19,9L20.25,6.26L23,5L20.25,3.75M9,4L6.5,9.5L1,12L6.5,14.5L9,20L11.5,14.5L17,12L11.5,9.5M19,15L17.74,17.74L15,19L17.74,20.25L19,23L20.25,20.25L23,19L20.25,17.74"

--- a/src/renderer/src/lib/icons/index.ts
+++ b/src/renderer/src/lib/icons/index.ts
@@ -19,6 +19,7 @@ export { default as Plus } from './Plus.svelte';
 export { default as Publisher } from './Publisher.svelte';
 export { default as ResizeIcon } from './ResizeIcon.svelte';
 export { default as Rocket } from './Rocket.svelte';
+export { default as UpdatesIcon } from './Updates.svelte';
 export { default as Upload } from './Upload.svelte';
 export { default as UploadImage } from './UploadImage.svelte';
 export { default as Verified } from './Verified.svelte';

--- a/src/renderer/src/lib/locale/en/common.json
+++ b/src/renderer/src/lib/locale/en/common.json
@@ -144,6 +144,7 @@
 	"uninstallAppAndRemoveAllData": "Uninstall this app and remove all associated data.",
 	"uninstallAppModalBody": "Are you sure you want to uninstall the app? This will delete all associated data.",
 	"update": "update",
+	"updates": "Updates",
 	"updateAppDetails": "Update App Details",
 	"updateAppDetailsExplanation": "Changing app details here will update the appearance of your app in app store.",
 	"updateAvailable": "Update available",

--- a/src/renderer/src/lib/locale/en/common.json
+++ b/src/renderer/src/lib/locale/en/common.json
@@ -71,6 +71,8 @@
 	"importedKey": "Imported key",
 	"initializingLairKeystore": "Initializing Lair Keystore...",
 	"install": "Install",
+	"installing": "installing",
+	"installAndRestart": "Install & Restart",
 	"installFromYourDevice": "Install from your device",
 	"installHapp": "Install Happ",
 	"installedSuccessfully": " installed successfully",

--- a/src/renderer/src/lib/stores/varia.ts
+++ b/src/renderer/src/lib/stores/varia.ts
@@ -1,0 +1,5 @@
+import { type Writable, writable } from 'svelte/store';
+
+import type { LauncherUpdate } from '$shared/types';
+
+export const launcherUpdateAvailable: Writable<LauncherUpdate | undefined> = writable(undefined);

--- a/src/renderer/src/lib/stores/varia.ts
+++ b/src/renderer/src/lib/stores/varia.ts
@@ -1,5 +1,0 @@
-import { type Writable, writable } from 'svelte/store';
-
-import type { LauncherUpdate } from '$shared/types';
-
-export const launcherUpdateAvailable: Writable<LauncherUpdate | undefined> = writable(undefined);

--- a/src/renderer/src/routes/(main)/+layout.svelte
+++ b/src/renderer/src/routes/(main)/+layout.svelte
@@ -33,6 +33,7 @@
 	const openApp = client.openApp.createMutation();
 	const hideApp = client.hideApp.createMutation();
 	const openSettings = client.openSettings.createMutation();
+	const launcherUpdateAvailableQuery = client.launcherUpdateAvailable.createQuery();
 
 	const utils = client.createUtils();
 
@@ -166,7 +167,7 @@
 	<IconButton onClick={() => $openSettings.mutate(undefined)}>
 		<div class="relative">
 			<Gear />
-			{#if Object.values($uiUpdates.data ?? {}).some(Boolean)}
+			{#if Object.values($uiUpdates.data ?? {}).some(Boolean) || $launcherUpdateAvailableQuery.data}
 				<div class="absolute -right-1 -top-1 h-3 w-3 rounded-full bg-warning-500"></div>
 			{/if}
 		</div>

--- a/src/renderer/src/routes/+layout.svelte
+++ b/src/renderer/src/routes/+layout.svelte
@@ -10,6 +10,8 @@
 		Toast
 	} from '@skeletonlabs/skeleton';
 	import { QueryClient, QueryClientProvider } from '@tanstack/svelte-query';
+	import TimeAgo from 'javascript-time-ago';
+	import en from 'javascript-time-ago/locale/en';
 
 	import { onNavigate } from '$app/navigation';
 	import {
@@ -52,6 +54,8 @@
 
 	initializeStores();
 	setupStorePopup();
+
+	TimeAgo.addDefaultLocale(en);
 </script>
 
 <QueryClientProvider client={queryClient}>

--- a/src/renderer/src/routes/+page.svelte
+++ b/src/renderer/src/routes/+page.svelte
@@ -13,6 +13,7 @@
 	const modalStore = getModalStore();
 
 	const lairSetupRequired = client.lairSetupRequired.createQuery();
+
 	onMount(() => {
 		const url = $page.url;
 

--- a/src/renderer/src/routes/settings/(menu)/[slug]/+page.svelte
+++ b/src/renderer/src/routes/settings/(menu)/[slug]/+page.svelte
@@ -6,7 +6,7 @@
 	import { goto } from '$app/navigation';
 	import { page } from '$app/stores';
 	import { AppDetailsPanel, Button } from '$components';
-	import { KEY_MANAGEMENT, MODAL_UNINSTALL_APP_CONFIRMATION } from '$const';
+	import { KEY_MANAGEMENT, LAUNCHER_UPDATES, MODAL_UNINSTALL_APP_CONFIRMATION } from '$const';
 	import {
 		capitalizeFirstLetter,
 		createImageUrl,
@@ -30,6 +30,7 @@
 	import AppSettings from './components/AppSettings.svelte';
 	import CellDetails from './components/CellDetails.svelte';
 	import KeyManagement from './components/KeyManagement.svelte';
+	import LauncherUpdates from './components/LauncherUpdates.svelte';
 	import SystemSettings from './components/SystemSettings.svelte';
 
 	const client = trpc();
@@ -293,6 +294,8 @@
 	{/if}
 {:else if $page.params.slug === KEY_MANAGEMENT}
 	<KeyManagement />
+{:else if $page.params.slug === LAUNCHER_UPDATES}
+	<LauncherUpdates />
 {:else}
 	<SystemSettings />
 {/if}

--- a/src/renderer/src/routes/settings/(menu)/[slug]/components/KeyManagement.svelte
+++ b/src/renderer/src/routes/settings/(menu)/[slug]/components/KeyManagement.svelte
@@ -1,16 +1,16 @@
 <script lang="ts">
-	import { getModalStore, getToastStore, SlideToggle } from '@skeletonlabs/skeleton';
+	import { getModalStore, getToastStore } from '@skeletonlabs/skeleton';
 
 	import { Button } from '$components';
+	import { MODAL_ENTER_PASSPHRASE } from '$const';
 	import { createModalParams, showModalError } from '$helpers';
 	import { Copy, Download } from '$icons';
 	import { i18n, trpc } from '$services';
 	import { getErrorMessage } from '$shared/helpers';
 	import { importedKeys } from '$stores';
+	import type { Modals } from '$types';
 
 	import { DashedSection } from '../../../components';
-	import { MODAL_ENTER_PASSPHRASE } from '$const';
-	import type { Modals } from '$types';
 
 	const modalStore = getModalStore();
 	const toastStore = getToastStore();
@@ -47,13 +47,16 @@
 		const target = event.target as HTMLInputElement;
 		const file = target.files?.[0];
 		if (file && file.type === 'application/json') {
-			$deriveAndImportSeedFromJsonFile.mutate({ filePath: file.path }, {
-				onError: handleError,
-				onSuccess: (result) => {
-					$importedKeys = [result, ...$importedKeys];
-					clearFileInput();
+			$deriveAndImportSeedFromJsonFile.mutate(
+				{ filePath: file.path },
+				{
+					onError: handleError,
+					onSuccess: (result) => {
+						$importedKeys = [result, ...$importedKeys];
+						clearFileInput();
+					}
 				}
-			});
+			);
 		}
 	};
 
@@ -95,50 +98,50 @@
 		});
 	};
 </script>
-<div class="py-3">
 
-<DashedSection containerClasses="m-2 p-2.5" title={$i18n.t('importSeedFile')}>
-	<div class="flex flex-col gap-2 overflow-hidden">
-		{#each $importedKeys as key}
-			<div class="flex items-center justify-between">
-				<span class="truncate whitespace-nowrap">
-					<span class="font-semibold">{$i18n.t('importedKey')}:</span>
-					<span class="truncate whitespace-nowrap font-light">{` ${key}`}</span>
-				</span>
+<div class="py-3">
+	<DashedSection containerClasses="m-2 p-2.5" title={$i18n.t('importSeedFile')}>
+		<div class="flex flex-col gap-2 overflow-hidden">
+			{#each $importedKeys as key}
+				<div class="flex items-center justify-between">
+					<span class="truncate whitespace-nowrap">
+						<span class="font-semibold">{$i18n.t('importedKey')}:</span>
+						<span class="truncate whitespace-nowrap font-light">{` ${key}`}</span>
+					</span>
+					<Button
+						props={{
+							class: ' flex',
+							onClick: async () => {
+								await navigator.clipboard.writeText(key);
+								toastStore.trigger({
+									message: $i18n.t('copiedToClipboard')
+								});
+							}
+						}}
+					>
+						<div class="ml-2 mr-1 pt-1"><Copy /></div>
+						{$i18n.t('copy')}
+					</Button>
+				</div>
+			{/each}
+			<input
+				type="file"
+				id="file-input-device-bundle"
+				class="!hidden"
+				accept=".json"
+				on:change={handleFileChange}
+			/>
+			<div class="flex items-center">
 				<Button
 					props={{
-						class: ' flex',
-						onClick: async () => {
-							await navigator.clipboard.writeText(key);
-							toastStore.trigger({
-								message: $i18n.t('copiedToClipboard')
-							});
-						}
+						class: 'btn-install flex',
+						onClick: () => document.getElementById('file-input-device-bundle')?.click()
 					}}
 				>
-					<div class="ml-2 mr-1 pt-1"><Copy /></div>
-					{$i18n.t('copy')}
+					<div class="mr-2"><Download /></div>
+					{$i18n.t($importedKeys.length ? 'importAdditionalSeed' : 'import')}
 				</Button>
-			</div>
-		{/each}
-		<input
-			type="file"
-			id="file-input-device-bundle"
-			class="!hidden"
-			accept=".json"
-			on:change={handleFileChange}
-		/>
-		<div class="flex items-center">
-			<Button
-				props={{
-					class: 'btn-install flex',
-					onClick: () => document.getElementById('file-input-device-bundle')?.click()
-				}}
-			>
-				<div class="mr-2"><Download /></div>
-				{$i18n.t($importedKeys.length ? 'importAdditionalSeed' : 'import')}
-			</Button>
-			<!-- <SlideToggle
+				<!-- <SlideToggle
 				on:click={() => {
 					insecurePassphraseCollection = !insecurePassphraseCollection;
 				}}
@@ -150,7 +153,7 @@
 			>
 				{insecurePassphraseCollection ? 'disable' : 'enable'} less secure passphrase collection
 			</SlideToggle> -->
+			</div>
 		</div>
-	</div>
-</DashedSection>
+	</DashedSection>
 </div>

--- a/src/renderer/src/routes/settings/(menu)/[slug]/components/LauncherUpdates.svelte
+++ b/src/renderer/src/routes/settings/(menu)/[slug]/components/LauncherUpdates.svelte
@@ -1,0 +1,104 @@
+<script lang="ts">
+	import TimeAgo from 'javascript-time-ago';
+
+	import { Button } from '$components';
+	import { markdownParseSafeTailwind } from '$helpers';
+	import { i18n, trpc } from '$services';
+	import { ProgressBar, getToastStore } from '@skeletonlabs/skeleton';
+	import { launcherUpdateAvailable } from '$stores/varia';
+	import { isLoading } from 'svelte-i18next';
+
+	// import { getModalStore } from '@skeletonlabs/skeleton';
+
+	const client = trpc();
+	const toastStore = getToastStore();
+
+	// 	export interface ProgressInfo {
+	//     total: number;
+	//     delta: number;
+	//     transferred: number;
+	//     percent: number;
+	//     bytesPerSecond: number;
+	// }
+	const launcherUpdateMutation = client.installLauncherUpdate.createMutation();
+
+	client.onLauncherUpdateDownloadProgress.createSubscription(undefined, {
+		onData: (progressInfo) => {
+			progressPercent = progressInfo.percent;
+		}
+	});
+	// const isDevhubInstalled = client.isDevhubInstalled.createQuery();
+	// const installDevhub = client.installDevhub.createMutation();
+	// const factoryReset = client.factoryReset.createMutation();
+
+	const timeAgo = new TimeAgo('en-US');
+	const releaseDate = Date.now() - 172800000;
+	const releaseNotes = `
+* fixes bugs that were introduced with 0.13.0-gamma.2 when switching the custom scheme to allow protecting the admin websocket
+* adds support for the \`onBeforeUnload\` event	`;
+
+	let progressPercent = 1;
+	let installing = false;
+
+	const installUpdate = () => {
+		installing = true;
+		$launcherUpdateMutation.mutate(undefined, {
+			onError: (error) => {
+				console.error(error);
+				installing = false;
+				toastStore.trigger({
+					message: `Failed to upload new release: ${error.message}`,
+					background: 'variant-filled-error'
+				});
+			}
+		});
+	};
+</script>
+
+<div class="flex flex-1 flex-col p-4">
+	{#if $launcherUpdateAvailable}
+		<div
+			class="drop-shadow-dark-xl m-5 rounded-md"
+			style="padding: 2px; background: linear-gradient(#f9d402, #8b7600);"
+		>
+			<div class="bg-dark-background flex flex-col rounded pb-4 pl-4 pr-4 pt-2">
+				<div class="flex flex-row items-center text-lg">
+					<div class="text-gray-400">New verison available</div>
+					<span class="flex flex-1"></span>
+					<div class="text-gray-400">
+						{timeAgo.format(new Date($launcherUpdateAvailable.releaseDate))}
+					</div>
+				</div>
+				<h1 class="h1">Holochain Launcher v{$launcherUpdateAvailable.version}</h1>
+				{#if $launcherUpdateAvailable.releaseNotes}
+					<div class="mt-2 text-lg text-gray-200">
+						{@html markdownParseSafeTailwind($launcherUpdateAvailable.releaseNotes)}
+					</div>
+				{/if}
+				<div class="mt-4 flex flex-row">
+					<span class="flex flex-1"></span>
+					<span class="flex flex-1"></span>
+					{#if !installing}
+						<Button
+							props={{
+								disabled: installing,
+								type: 'submit',
+								class: 'btn-happ-button flex-1',
+								onClick: installUpdate
+							}}
+						>
+							<span>{$i18n.t('installAndRestart')}</span>
+						</Button>
+					{:else}
+						<div class="flex flex-1 flex-col">
+							<div class="mb-1">{$i18n.t('installing')}...</div>
+							<ProgressBar value={progressPercent} max={100} meter="bg-amber-400" />
+						</div>
+					{/if}
+				</div>
+			</div>
+		</div>
+	{:else}
+		<div>No updates.</div>
+	{/if}
+</div>

--- a/src/renderer/src/routes/settings/(menu)/[slug]/components/LauncherUpdates.svelte
+++ b/src/renderer/src/routes/settings/(menu)/[slug]/components/LauncherUpdates.svelte
@@ -5,8 +5,6 @@
 	import { markdownParseSafeTailwind } from '$helpers';
 	import { i18n, trpc } from '$services';
 	import { ProgressBar, getToastStore } from '@skeletonlabs/skeleton';
-	import { launcherUpdateAvailable } from '$stores/varia';
-	import { isLoading } from 'svelte-i18next';
 
 	// import { getModalStore } from '@skeletonlabs/skeleton';
 
@@ -21,21 +19,15 @@
 	//     bytesPerSecond: number;
 	// }
 	const launcherUpdateMutation = client.installLauncherUpdate.createMutation();
+	const launcherUpdateAvailableQuery = client.launcherUpdateAvailable.createQuery();
 
 	client.onLauncherUpdateDownloadProgress.createSubscription(undefined, {
 		onData: (progressInfo) => {
 			progressPercent = progressInfo.percent;
 		}
 	});
-	// const isDevhubInstalled = client.isDevhubInstalled.createQuery();
-	// const installDevhub = client.installDevhub.createMutation();
-	// const factoryReset = client.factoryReset.createMutation();
 
 	const timeAgo = new TimeAgo('en-US');
-	const releaseDate = Date.now() - 172800000;
-	const releaseNotes = `
-* fixes bugs that were introduced with 0.13.0-gamma.2 when switching the custom scheme to allow protecting the admin websocket
-* adds support for the \`onBeforeUnload\` event	`;
 
 	let progressPercent = 1;
 	let installing = false;
@@ -56,7 +48,7 @@
 </script>
 
 <div class="flex flex-1 flex-col p-4">
-	{#if $launcherUpdateAvailable}
+	{#if $launcherUpdateAvailableQuery.isSuccess && $launcherUpdateAvailableQuery.data}
 		<div
 			class="drop-shadow-dark-xl m-5 rounded-md"
 			style="padding: 2px; background: linear-gradient(#f9d402, #8b7600);"
@@ -66,13 +58,13 @@
 					<div class="text-gray-400">New verison available</div>
 					<span class="flex flex-1"></span>
 					<div class="text-gray-400">
-						{timeAgo.format(new Date($launcherUpdateAvailable.releaseDate))}
+						{timeAgo.format(new Date($launcherUpdateAvailableQuery.data.releaseDate))}
 					</div>
 				</div>
-				<h1 class="h1">Holochain Launcher v{$launcherUpdateAvailable.version}</h1>
-				{#if $launcherUpdateAvailable.releaseNotes}
+				<h1 class="h1">Holochain Launcher v{$launcherUpdateAvailableQuery.data.version}</h1>
+				{#if $launcherUpdateAvailableQuery.data.releaseNotes}
 					<div class="mt-2 text-lg text-gray-200">
-						{@html markdownParseSafeTailwind($launcherUpdateAvailable.releaseNotes)}
+						{@html markdownParseSafeTailwind($launcherUpdateAvailableQuery.data.releaseNotes)}
 					</div>
 				{/if}
 				<div class="mt-4 flex flex-row">

--- a/src/renderer/src/routes/settings/(menu)/[slug]/components/LauncherUpdates.svelte
+++ b/src/renderer/src/routes/settings/(menu)/[slug]/components/LauncherUpdates.svelte
@@ -6,18 +6,9 @@
 	import { i18n, trpc } from '$services';
 	import { ProgressBar, getToastStore } from '@skeletonlabs/skeleton';
 
-	// import { getModalStore } from '@skeletonlabs/skeleton';
-
 	const client = trpc();
 	const toastStore = getToastStore();
 
-	// 	export interface ProgressInfo {
-	//     total: number;
-	//     delta: number;
-	//     transferred: number;
-	//     percent: number;
-	//     bytesPerSecond: number;
-	// }
 	const launcherUpdateMutation = client.installLauncherUpdate.createMutation();
 	const launcherUpdateAvailableQuery = client.launcherUpdateAvailable.createQuery();
 

--- a/src/renderer/src/routes/settings/components/MenuEntry.svelte
+++ b/src/renderer/src/routes/settings/components/MenuEntry.svelte
@@ -8,39 +8,44 @@
 	export let name: string;
 	export let isSelected = false;
 	export let isUpdateAvailable = false;
-	export let background = 'bg-white/25';
 	export let icon: Uint8Array | undefined = undefined;
 	export let disabled = false;
+	export let extra: string | undefined = undefined;
 </script>
 
 <button
 	class={clsx(
-		`flex cursor-pointer items-center px-4 py-2 hover:${background} hover:rounded-md`,
-		isSelected && `rounded-md ${background}`,
+		`flex cursor-pointer items-center px-4 py-2 hover:rounded-md hover:bg-white/25`,
+		isSelected && `rounded-md bg-white/25`,
 		disabled && 'cursor-default opacity-50'
 	)}
 	on:click={onClick}
 	aria-label={`Select ${name}`}
 	{disabled}
 >
-	<slot name="leading">
-		<Avatar
-			src={createImageUrl(icon)}
-			initials={name.substring(0, 2).toUpperCase()}
-			fill="fill-current text-white"
-			background="dark:bg-app-gradient"
-			fontSize={250}
-			width="w-5 mr-4"
-			rounded="rounded-sm"
-		/>
-	</slot>
-	<span
-		class={clsx('text-base', {
-			'font-light opacity-80': !isSelected,
-			'font-semibold': isSelected || isUpdateAvailable
-		})}>{name}</span
-	>
-	{#if isUpdateAvailable}
-		<div class="ml-2 h-3 w-3 rounded-full bg-warning-500"></div>
-	{/if}
+	<div class="flex flex-row items-center">
+		<slot name="leading">
+			<Avatar
+				src={createImageUrl(icon)}
+				initials={name.substring(0, 2).toUpperCase()}
+				fill="fill-current text-white"
+				background="dark:bg-app-gradient"
+				fontSize={250}
+				width="w-5 mr-4"
+				rounded="rounded-sm"
+			/>
+		</slot>
+		<span
+			class={clsx('text-base', {
+				'font-light opacity-80': !isSelected,
+				'font-semibold': isSelected || isUpdateAvailable
+			})}>{name}</span
+		>
+		{#if extra}
+			<span class="ml-2 font-bold font text-warning-500">NEW</span>
+		{/if}
+		{#if isUpdateAvailable}
+			<div class="ml-2 h-3 w-3 rounded-full bg-warning-500"></div>
+		{/if}
+	</div>
 </button>

--- a/src/renderer/src/routes/settings/components/RegularMenu.svelte
+++ b/src/renderer/src/routes/settings/components/RegularMenu.svelte
@@ -8,6 +8,7 @@
 	import { CenterProgressRadial } from '$components';
 	import {
 		KEY_MANAGEMENT,
+		LAUNCHER_UPDATES,
 		NOT_SELECTED_ICON_STYLE,
 		SELECTED_ICON_STYLE,
 		SYSTEM_INFORMATION,
@@ -20,7 +21,7 @@
 		showModalError,
 		validateApp
 	} from '$helpers';
-	import { Gear, Key, MenuInfo } from '$icons';
+	import { Gear, Key, MenuInfo, UpdatesIcon } from '$icons';
 	import { createAppQueries } from '$queries';
 	import { i18n, trpc } from '$services';
 	import { DISTRIBUTION_TYPE_APPSTORE, SETTINGS_WINDOW } from '$shared/const';
@@ -31,6 +32,8 @@
 	const modalStore = getModalStore();
 
 	const installedApps = client.getInstalledApps.createQuery(true);
+
+	const launcherUpdateAvailable = client.launcherUpdateAvailable.createQuery();
 
 	const { checkForAppUiUpdatesQuery } = createAppQueries();
 
@@ -81,6 +84,17 @@
 			iconStyle: 'mr-3'
 		}
 	];
+
+	launcherUpdateAvailable.subscribe((val) => {
+		if ((val.isSuccess && val.data) || true) {
+			menuEntries.unshift({
+				name: $i18n.t(LAUNCHER_UPDATES),
+				view: LAUNCHER_UPDATES,
+				icon: UpdatesIcon,
+				iconStyle: 'ml-[1.5px] mr-[14px]'
+			});
+		}
+	});
 </script>
 
 <span class="pb-2 text-sm">{$i18n.t('launcherSettings')}</span>

--- a/src/renderer/src/routes/settings/components/RegularMenu.svelte
+++ b/src/renderer/src/routes/settings/components/RegularMenu.svelte
@@ -32,8 +32,7 @@
 	const modalStore = getModalStore();
 
 	const installedApps = client.getInstalledApps.createQuery(true);
-
-	const launcherUpdateAvailable = client.launcherUpdateAvailable.createQuery();
+	const launcherUpdateAvailableQuery = client.launcherUpdateAvailable.createQuery();
 
 	const { checkForAppUiUpdatesQuery } = createAppQueries();
 
@@ -64,7 +63,16 @@
 
 	$: view = $page.params.slug || '';
 
-	const menuEntries = [
+	type MenuEntryInfo = {
+		name: string;
+		view: string;
+		icon: any;
+		iconStyle: string;
+		extra?: string;
+		isUpdateAvailable?: boolean;
+	};
+
+	let menuEntries: MenuEntryInfo[] = [
 		{
 			name: $i18n.t(SYSTEM_INFORMATION),
 			view: '',
@@ -85,21 +93,37 @@
 		}
 	];
 
-	launcherUpdateAvailable.subscribe((val) => {
-		if ((val.isSuccess && val.data) || true) {
-			menuEntries.unshift({
-				name: $i18n.t(LAUNCHER_UPDATES),
-				view: LAUNCHER_UPDATES,
-				icon: UpdatesIcon,
-				iconStyle: 'ml-[1.5px] mr-[14px]'
-			});
+	const launcherUpdateMenuEntry = {
+		name: $i18n.t(LAUNCHER_UPDATES),
+		view: LAUNCHER_UPDATES,
+		icon: UpdatesIcon,
+		iconStyle: 'ml-[1.5px] mr-[14px]',
+		extra: 'NEW'
+	};
+
+
+	launcherUpdateAvailableQuery.subscribe((val) => {
+		console.log(Date.now(), 'LAUNCHER UPDATE AVAILABLE CHANGED: ', val);
+		if (val.isSuccess && val.data) {
+			if (!menuEntries.map((entry) => entry.name).includes($i18n.t(LAUNCHER_UPDATES))) {
+				console.log('pushing menu entry.');
+				const newMenuEntries = menuEntries;
+				newMenuEntries.unshift(launcherUpdateMenuEntry);
+				menuEntries = newMenuEntries;
+			}
 		}
 	});
 </script>
 
 <span class="pb-2 text-sm">{$i18n.t('launcherSettings')}</span>
-{#each menuEntries as { name, view: entryView, icon: Icon, iconStyle }}
-	<MenuEntry {name} onClick={() => selectView(entryView)} isSelected={view === entryView}>
+{#each menuEntries as { name, view: entryView, icon: Icon, iconStyle, extra, isUpdateAvailable }}
+	<MenuEntry
+		{name}
+		{extra}
+		{isUpdateAvailable}
+		onClick={() => selectView(entryView)}
+		isSelected={view === entryView}
+	>
 		<div slot="leading" class={clsx(iconStyle, view !== entryView)}>
 			<Icon fillColor={view === entryView ? SELECTED_ICON_STYLE : NOT_SELECTED_ICON_STYLE} />
 		</div>

--- a/src/renderer/src/routes/settings/components/RegularMenu.svelte
+++ b/src/renderer/src/routes/settings/components/RegularMenu.svelte
@@ -101,16 +101,14 @@
 		extra: 'NEW'
 	};
 
-
 	launcherUpdateAvailableQuery.subscribe((val) => {
 		console.log(Date.now(), 'LAUNCHER UPDATE AVAILABLE CHANGED: ', val);
-		if (val.isSuccess && val.data) {
-			if (!menuEntries.map((entry) => entry.name).includes($i18n.t(LAUNCHER_UPDATES))) {
-				console.log('pushing menu entry.');
-				const newMenuEntries = menuEntries;
-				newMenuEntries.unshift(launcherUpdateMenuEntry);
-				menuEntries = newMenuEntries;
-			}
+		if (
+			val.isSuccess &&
+			val.data &&
+			!menuEntries.map((entry) => entry.name).includes($i18n.t(LAUNCHER_UPDATES))
+		) {
+			menuEntries = [launcherUpdateMenuEntry, ...menuEntries];
 		}
 	});
 </script>

--- a/src/renderer/tailwind.config.ts
+++ b/src/renderer/tailwind.config.ts
@@ -16,7 +16,8 @@ export default {
 			colors: {
 				'light-primary': 'rgb(25, 182, 227)',
 				'light-background': 'rgba(0, 102, 255, 0.1)',
-				'transparent-gray': '#dadada12'
+				'transparent-gray': '#dadada12',
+				'dark-background': '#000b1a'
 			},
 			backgroundImage: {
 				'login-background': "url('/images/login-background.png')",
@@ -34,6 +35,9 @@ export default {
 			},
 			boxShadow: {
 				'3xl': '0 35px 60px -15px rgba(0, 0, 0)'
+			},
+			dropShadow: {
+				'dark-xl': '2px 2px 10px #000b1a'
 			}
 		}
 	},

--- a/src/shared/types/eventEmitters.ts
+++ b/src/shared/types/eventEmitters.ts
@@ -1,7 +1,10 @@
+import type { ProgressInfo } from '@matthme/electron-updater';
+
 import type { HolochainData, LoadingProgressUpdate } from './holochain';
 
 export const LOADING_PROGRESS_UPDATE = 'loading-progress-update';
 export const DOWNLOAD_PROGRESS_UPDATE = 'download-progress-update';
+export const LAUNCHER_UPDATE_DOWNLOAD_PROGRESS = 'update-download-progress-update';
 export const REFETCH_DATA_IN_ALL_WINDOWS = 'refetch-data-in-all-windows';
 export const APP_INSTALLED = 'app-installed';
 export const HIDE_SETTINGS_WINDOW = 'hide-settings-window';
@@ -19,6 +22,7 @@ export const WASM_LOG = 'wasm-log';
 export type EventMap = {
   [LOADING_PROGRESS_UPDATE]: LoadingProgressUpdate;
   [DOWNLOAD_PROGRESS_UPDATE]: string;
+  [LAUNCHER_UPDATE_DOWNLOAD_PROGRESS]: ProgressInfo;
   [APP_INSTALLED]: HolochainData;
   [LAUNCHER_ERROR]: string;
   [LAUNCHER_LOG]: string;

--- a/src/shared/types/launcher.ts
+++ b/src/shared/types/launcher.ts
@@ -13,6 +13,12 @@ import {
 } from '../const';
 import type { HolochainDataRoot } from './holochain';
 
+export type LauncherUpdate = {
+  version: string;
+  releaseDate: string;
+  releaseNotes: string | undefined;
+};
+
 type UrlAndSha256 = {
   version: string;
   sha256: Sha256;

--- a/src/shared/types/launcher.ts
+++ b/src/shared/types/launcher.ts
@@ -16,7 +16,7 @@ import type { HolochainDataRoot } from './holochain';
 export type LauncherUpdate = {
   version: string;
   releaseDate: string;
-  releaseNotes: string | undefined;
+  releaseNotes?: string;
 };
 
 type UrlAndSha256 = {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1209,6 +1209,13 @@
   resolved "https://registry.yarnpkg.com/@types/dom-view-transitions/-/dom-view-transitions-1.0.4.tgz#b4310929488daa6baa8bba657404ea6e05724121"
   integrity sha512-oDuagM6G+xPLrLU4KeCKlr1oalMF5mJqV5pDPMDVIEaa8AkUW00i6u+5P02XCjdEEUQJC9dpnxqSLsZeAciSLQ==
 
+"@types/dompurify@3.0.5":
+  version "3.0.5"
+  resolved "https://registry.yarnpkg.com/@types/dompurify/-/dompurify-3.0.5.tgz#02069a2fcb89a163bacf1a788f73cb415dd75cb7"
+  integrity sha512-1Wg0g3BtQF7sSb27fJQAKck1HECM6zV1EB66j8JH9i3LCjYabJa0FSdiSgsD5K/RbrsR0SiraKacLB+T8ZVYAg==
+  dependencies:
+    "@types/trusted-types" "*"
+
 "@types/elliptic@6.4.18":
   version "6.4.18"
   resolved "https://registry.yarnpkg.com/@types/elliptic/-/elliptic-6.4.18.tgz#bc96e26e1ccccbabe8b6f0e409c85898635482e1"
@@ -1309,7 +1316,7 @@
   resolved "https://registry.yarnpkg.com/@types/triple-beam/-/triple-beam-1.3.5.tgz#74fef9ffbaa198eb8b588be029f38b00299caa2c"
   integrity sha512-6WaYesThRMCl19iryMYP7/x2OVgCtbIVflDGFpWnb9irXI3UjYE4AzmYuiUKY1AJstGijoY+MgUszMgRxIYTYw==
 
-"@types/trusted-types@^2.0.2":
+"@types/trusted-types@*", "@types/trusted-types@^2.0.2":
   version "2.0.7"
   resolved "https://registry.yarnpkg.com/@types/trusted-types/-/trusted-types-2.0.7.tgz#baccb07a970b91707df3a3e8ba6896c57ead2d11"
   integrity sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==
@@ -2316,6 +2323,11 @@ domhandler@^5.0.2:
   integrity sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==
   dependencies:
     domelementtype "^2.3.0"
+
+dompurify@3.1.5:
+  version "3.1.5"
+  resolved "https://registry.yarnpkg.com/dompurify/-/dompurify-3.1.5.tgz#2c6a113fc728682a0f55684b1388c58ddb79dc38"
+  integrity sha512-lwG+n5h8QNpxtyrJW/gJWckL+1/DQiYMX8f7t8Z2AZTPw1esVrqjI63i7Zc2Gz0aKzLVMYC1V1PL/ky+aY/NgA==
 
 dotenv-expand@^5.1.0:
   version "5.1.0"
@@ -3480,6 +3492,13 @@ jake@^10.8.5:
     filelist "^1.0.4"
     minimatch "^3.1.2"
 
+javascript-time-ago@2.5.9:
+  version "2.5.9"
+  resolved "https://registry.yarnpkg.com/javascript-time-ago/-/javascript-time-ago-2.5.9.tgz#3c5d8012cd493d764c6b26a0ffe6e8b20afcf1fe"
+  integrity sha512-pQ8mNco/9g9TqWXWWjP0EWl6i/lAQScOyEeXy5AB+f7MfLSdgyV9BJhiOD1zrIac/lrxPYOWNbyl/IW8CW5n0A==
+  dependencies:
+    relative-time-format "^1.1.6"
+
 jiti@^1.21.0:
   version "1.21.0"
   resolved "https://registry.yarnpkg.com/jiti/-/jiti-1.21.0.tgz#7c97f8fe045724e136a397f7340475244156105d"
@@ -3797,6 +3816,11 @@ magic-string@^0.30.4, magic-string@^0.30.5:
   integrity sha512-S1+hd+dIrC8EZqKyT9DstTH/0Z+f76kmmvZnkfQVmOpDEF9iVgdYif3Q/pIWHmCoo59bQVGW0kVL3e2nl+9+Sw==
   dependencies:
     "@jridgewell/sourcemap-codec" "^1.4.15"
+
+marked@12.0.2:
+  version "12.0.2"
+  resolved "https://registry.yarnpkg.com/marked/-/marked-12.0.2.tgz#b31578fe608b599944c69807b00f18edab84647e"
+  integrity sha512-qXUm7e/YKFoqFPYPa3Ukg9xlI5cyAtGmyEIzMfW//m6kXwCy2Ps9DYf5ioijFKQ8qyuscrHoY04iJGctu2Kg0Q==
 
 matcher@^3.0.0:
   version "3.0.0"
@@ -4521,6 +4545,11 @@ regenerator-runtime@^0.14.0:
   version "0.14.1"
   resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.14.1.tgz#356ade10263f685dda125100cd862c1db895327f"
   integrity sha512-dYnhHh0nJoMfnkZs6GmmhFknAGRrLznOu5nc9ML+EJxGvrx6H7teuevqVqCuPcPK//3eDrrjQhehXVx9cnkGdw==
+
+relative-time-format@^1.1.6:
+  version "1.1.6"
+  resolved "https://registry.yarnpkg.com/relative-time-format/-/relative-time-format-1.1.6.tgz#724a5fbc3794b8e0471b6b61419af2ce699eb9f1"
+  integrity sha512-aCv3juQw4hT1/P/OrVltKWLlp15eW1GRcwP1XdxHrPdZE9MtgqFpegjnTjLhi2m2WI9MT/hQQtE+tjEWG1hgkQ==
 
 require-directory@^2.1.1:
   version "2.1.1"


### PR DESCRIPTION
This PR improves the UI around automatic updates (issue https://github.com/holochain/launcher/issues/202) following Figma screens that were created a few weeks ago (not exactly 1:1 but quite similarly).

* it creates an "Updates" section in settings that only shows up if there is an update available
* it displays an orange dot on the settings gear if a new update is available
* it displays information about the update in the updates section like changelog, version number, release time and lets you download & install the update and restart launcher (with a loading indicator)

To test this PR:
* change the version field in the root level package.json to `0.400.0-rc.1`
* build the launcher executable locally with `yarn build:build:mac-arm64` or `yarn build:linux`etc.
* start launcher and verify that it offers to update to the latest compatible release (at the time of writing `0.400.0-rc.2`) 