### PR TITLE
Use `SODIUM_DIST_DIR` variable

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -88,6 +88,8 @@ jobs:
           mkdir libsodium
           curl -L --output ./libsodium/LATEST.tar.gz https://drive.switch.ch/index.php/s/mFjiYO83NfrgePN/download
           curl -L --output ./libsodium/LATEST.tar.gz.minisig https://drive.switch.ch/index.php/s/oCfe15GFtdD8myX/download
+          curl -L --output ./libsodium/libsodium-1.0.19-stable-msvc.zip https://drive.switch.ch/index.php/s/JSgCCXrXYSdI22v/download
+          curl -L --output ./libsodium/libsodium-1.0.19-stable-msvc.zip.minisig https://drive.switch.ch/index.php/s/lpqZ9m5nccrq2HG/download
 
 
       - name: Conditionally Setup rust-utils

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -2,7 +2,7 @@ name: 'publish'
 on:
   push:
     branches:
-      - release
+      - sodium-dist-dir
 
 jobs:
   extract-versions:
@@ -75,16 +75,26 @@ jobs:
         with:
           go-version: 'stable'
 
-      - name: Cache rust-utils build
-        id: cache-rust-utils
-        uses: actions/cache@v4
-        with:
-          path: rust-utils/dist
-          key: ${{ matrix.platform }}-rust-utils-${{ needs.extract-versions.outputs.rust_utils_version }}
+      # - name: Cache rust-utils build
+      #   id: cache-rust-utils
+      #   uses: actions/cache@v4
+      #   with:
+      #     path: rust-utils/dist
+      #     key: ${{ matrix.platform }}-rust-utils-${{ needs.extract-versions.outputs.rust_utils_version }}
+
+      - name: Download libsodium
+        if: matrix.platform == 'windows-2019'
+        run: |
+          mkdir libsodium
+          curl -L --output ./libsodium/libsodium-stable.tar.gz https://drive.switch.ch/index.php/s/mFjiYO83NfrgePN/download
+          curl -L --output ./libsodium/libsodium-stable.tar.gz.minisig https://drive.switch.ch/index.php/s/oCfe15GFtdD8myX/download
+
 
       - name: Conditionally Setup rust-utils
-        if: steps.cache-rust-utils.outputs.cache-hit != 'true'
-        run: yarn build:rust-utils
+        # if: steps.cache-rust-utils.outputs.cache-hit != 'true'
+        run: |
+          $env:SODIUM_DIST_DIR="$(pwd)\libsodium"
+          yarn build:rust-utils
 
       - name: build and install libs and dependencies
         run: yarn build:libs

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -33,9 +33,9 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        platform: [windows-2019, macos-13, macos-latest, ubuntu-22.04]
+        # platform: [windows-2019, macos-13, macos-latest, ubuntu-22.04]
         # platform: [ubuntu-22.04, macos-13]
-        # platform: [windows-2019]
+        platform: [windows-2019]
     env:
       MACOSX_DEPLOYMENT_TARGET: 10.13
 

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -2,7 +2,7 @@ name: 'publish'
 on:
   push:
     branches:
-      - sodium-dist-dir
+      - release
 
 jobs:
   extract-versions:
@@ -33,9 +33,9 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # platform: [windows-2019, macos-13, macos-latest, ubuntu-22.04]
+        platform: [windows-2019, macos-13, macos-latest, ubuntu-22.04]
         # platform: [ubuntu-22.04, macos-13]
-        platform: [windows-2019]
+        # platform: [windows-2019]
     env:
       MACOSX_DEPLOYMENT_TARGET: 10.13
 
@@ -75,28 +75,32 @@ jobs:
         with:
           go-version: 'stable'
 
-      # - name: Cache rust-utils build
-      #   id: cache-rust-utils
-      #   uses: actions/cache@v4
-      #   with:
-      #     path: rust-utils/dist
-      #     key: ${{ matrix.platform }}-rust-utils-${{ needs.extract-versions.outputs.rust_utils_version }}
+      - name: Cache rust-utils build
+        id: cache-rust-utils
+        uses: actions/cache@v4
+        with:
+          path: rust-utils/dist
+          key: ${{ matrix.platform }}-rust-utils-${{ needs.extract-versions.outputs.rust_utils_version }}
 
       - name: Download libsodium
         if: matrix.platform == 'windows-2019'
         run: |
           mkdir libsodium
-          curl -L --output ./libsodium/LATEST.tar.gz https://drive.switch.ch/index.php/s/mFjiYO83NfrgePN/download
-          curl -L --output ./libsodium/LATEST.tar.gz.minisig https://drive.switch.ch/index.php/s/oCfe15GFtdD8myX/download
-          curl -L --output ./libsodium/libsodium-1.0.19-stable-msvc.zip https://drive.switch.ch/index.php/s/JSgCCXrXYSdI22v/download
-          curl -L --output ./libsodium/libsodium-1.0.19-stable-msvc.zip.minisig https://drive.switch.ch/index.php/s/lpqZ9m5nccrq2HG/download
+          curl -L --output ./libsodium/LATEST.tar.gz https://github.com/matthme/holochain-binaries/releases/download/libsodium-releases/LATEST.tar.gz
+          curl -L --output ./libsodium/LATEST.tar.gz.minisig https://github.com/matthme/holochain-binaries/releases/download/libsodium-releases/LATEST.tar.gz.minisig
+          curl -L --output ./libsodium/libsodium-1.0.19-stable-msvc.zip https://github.com/matthme/holochain-binaries/releases/download/libsodium-releases/libsodium-1.0.19-stable-msvc.zip
+          curl -L --output ./libsodium/libsodium-1.0.19-stable-msvc.zip.minisig https://github.com/matthme/holochain-binaries/releases/download/libsodium-releases/libsodium-1.0.19-stable-msvc.zip.minisig
 
 
-      - name: Conditionally Setup rust-utils
-        # if: steps.cache-rust-utils.outputs.cache-hit != 'true'
+      - name: Conditionally Setup rust-utils (Windows)
+        if: steps.cache-rust-utils.outputs.cache-hit != 'true' && matrix.platform == 'windows-2019'
         run: |
           $env:SODIUM_DIST_DIR="$(pwd)\libsodium"
           yarn build:rust-utils
+
+      - name: Conditionally Setup rust-utils (macOS & Linux)
+        if: steps.cache-rust-utils.outputs.cache-hit != 'true' && matrix.platform != 'windows-2019'
+        run: yarn build:rust-utils
 
       - name: build and install libs and dependencies
         run: yarn build:libs

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -86,8 +86,8 @@ jobs:
         if: matrix.platform == 'windows-2019'
         run: |
           mkdir libsodium
-          curl -L --output ./libsodium/libsodium-stable.tar.gz https://drive.switch.ch/index.php/s/mFjiYO83NfrgePN/download
-          curl -L --output ./libsodium/libsodium-stable.tar.gz.minisig https://drive.switch.ch/index.php/s/oCfe15GFtdD8myX/download
+          curl -L --output ./libsodium/LATEST.tar.gz https://drive.switch.ch/index.php/s/mFjiYO83NfrgePN/download
+          curl -L --output ./libsodium/LATEST.tar.gz.minisig https://drive.switch.ch/index.php/s/oCfe15GFtdD8myX/download
 
 
       - name: Conditionally Setup rust-utils


### PR DESCRIPTION
This PR downloads libsodium from another source and uses the `SODIUM_DIST_DIR` variable, in order to circumvent download issues in CI.